### PR TITLE
Fixes in examples (PyOpenGL and PyQT5)

### DIFF
--- a/Examples/PyOpenGL/01_HelloWorld.py
+++ b/Examples/PyOpenGL/01_HelloWorld.py
@@ -14,7 +14,7 @@ except NullFunctionError as ex:
 
 glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH)
 glutInitWindowSize(800, 600)
-glutCreateWindow('')
+glutCreateWindow(b'01 HelloWorld')
 
 GL.Init()
 

--- a/Examples/PyOpenGL/02_UniformsAndAttributes.py
+++ b/Examples/PyOpenGL/02_UniformsAndAttributes.py
@@ -9,7 +9,7 @@ start = time.time()
 glutInit(sys.argv)
 glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH)
 glutInitWindowSize(width, height)
-glutCreateWindow('')
+glutCreateWindow(b'02 Uniforms and attributes')
 
 GL.Init()
 

--- a/Examples/PyOpenGL/03_Blending.py
+++ b/Examples/PyOpenGL/03_Blending.py
@@ -9,7 +9,7 @@ start = time.time()
 glutInit(sys.argv)
 glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH)
 glutInitWindowSize(width, height)
-glutCreateWindow('')
+glutCreateWindow(b'03 Blending')
 
 GL.Init()
 

--- a/Examples/PyOpenGL/04_Texture.py
+++ b/Examples/PyOpenGL/04_Texture.py
@@ -9,7 +9,7 @@ start = time.time()
 glutInit(sys.argv)
 glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH)
 glutInitWindowSize(width, height)
-glutCreateWindow('')
+glutCreateWindow(b'04 Texture')
 
 GL.Init()
 

--- a/Examples/PyQt5/Raytrace.py
+++ b/Examples/PyQt5/Raytrace.py
@@ -96,7 +96,7 @@ class QGLControllerWidget(QtOpenGL.QGLWidget):
 				}
 			''')
 
-			prog, iface = GL.NewProgram([vert, frag])
+			prog = GL.NewProgram([vert, frag])
 
 			vbo = GL.NewVertexBuffer(struct.pack('8f', -1.0, -1.0, -1.0, 1.0, 1.0, -1.0, 1.0, 1.0))
 			context['vao'] = GL.NewVertexArray(prog, vbo, '2f', ['vert'])
@@ -104,9 +104,9 @@ class QGLControllerWidget(QtOpenGL.QGLWidget):
 			ssbo = GL.NewStorageBuffer(open('../DataFiles/Raytrace-scene.dat', 'rb').read())
 			GL.UseStorageBuffer(ssbo, 1)
 
-			GL.SetUniform(iface['ratio'], context['width'] / context['height'])
-			GL.SetUniform(iface['position'], 0.7, 0.7, 0.0)
-			GL.SetUniform(iface['target'], 0, 0, 0)
+			GL.SetUniform(prog['ratio'], context['width'] / context['height'])
+			GL.SetUniform(prog['position'], 0.7, 0.7, 0.0)
+			GL.SetUniform(prog['target'], 0, 0, 0)
 
 		except GL.Error as error:
 			print(error)


### PR DESCRIPTION
PyOpenGL:
The call to glutCreateWindow want the argument to be of type byte no str.
Error: ctypes.ArgumentError: argument 1: <class 'TypeError'>: wrong type

Changed glutCreateWindow('') to glutCreateWindow(b'').

PyQT5 (Raytracer example):
Crash using the iface. Changed to use only the prog
prog, iface = GL.NewProgram([vert, frag])
TypeError: 'ModernGL.Program' object is not iterable

------------------------
Also added a name to the windows to have the example name in the PyOpenGL examples.