### PR TITLE
Fix color attachments

### DIFF
--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -949,6 +949,8 @@ MGLFramebuffer * MGLContext_framebuffer(MGLContext * self, PyObject * args) {
 	int height = 0;
 	int samples = 0;
 
+	bool new_depth_attachment = false; // TODO: better
+
 	int color_attachments_len = (int)PyTuple_GET_SIZE(color_attachments);
 
 	if (!color_attachments_len) {
@@ -1045,8 +1047,8 @@ MGLFramebuffer * MGLContext_framebuffer(MGLContext * self, PyObject * args) {
 		Py_INCREF(self);
 		renderbuffer->context = self;
 
-		Py_INCREF(renderbuffer);
 		depth_attachment = (PyObject *)renderbuffer;
+		new_depth_attachment = true;
 
 	}
 
@@ -1175,6 +1177,12 @@ MGLFramebuffer * MGLContext_framebuffer(MGLContext * self, PyObject * args) {
 		framebuffer->color_mask[i * 4 + 1] = attachment->components >= 2;
 		framebuffer->color_mask[i * 4 + 2] = attachment->components >= 3;
 		framebuffer->color_mask[i * 4 + 3] = attachment->components >= 4;
+	}
+
+	Py_INCREF(color_attachments);
+
+	if (!new_depth_attachment) {
+		Py_INCREF(depth_attachment);
 	}
 
 	framebuffer->depth_mask = true;

--- a/tests/basic/test_simple_framebuffer.py
+++ b/tests/basic/test_simple_framebuffer.py
@@ -20,6 +20,26 @@ class TestCase(unittest.TestCase):
         rbo = self.ctx.renderbuffer((16, 16))
         self.ctx.framebuffer(rbo)
 
+    def test_framebuffer_get_color_attachment(self):
+        rbo1 = self.ctx.renderbuffer((16, 16))
+        rbo2 = self.ctx.renderbuffer((16, 16))
+        rbo3 = self.ctx.renderbuffer((16, 16))
+
+        fbo1 = self.ctx.framebuffer(rbo1)
+        fbo2 = self.ctx.framebuffer([rbo2, rbo1])
+        fbo3 = self.ctx.framebuffer([rbo1, rbo2, rbo3])
+
+        self.assertEqual(len(fbo1.color_attachments), 1)
+        self.assertEqual(len(fbo2.color_attachments), 2)
+        self.assertEqual(len(fbo3.color_attachments), 3)
+
+        self.assertIsInstance(fbo1.color_attachments[0], ModernGL.Renderbuffer)
+        self.assertIsInstance(fbo2.color_attachments[0], ModernGL.Renderbuffer)
+        self.assertIsInstance(fbo2.color_attachments[1], ModernGL.Renderbuffer)
+        self.assertIsInstance(fbo3.color_attachments[0], ModernGL.Renderbuffer)
+        self.assertIsInstance(fbo3.color_attachments[1], ModernGL.Renderbuffer)
+        self.assertIsInstance(fbo3.color_attachments[2], ModernGL.Renderbuffer)
+
     def test_framebuffer_color_mask(self):
         fbo = self.ctx.framebuffer(self.ctx.renderbuffer((16, 16)))
         self.assertEqual(fbo.color_mask, (True, True, True, True))

--- a/tests/basic/test_simple_framebuffer.py
+++ b/tests/basic/test_simple_framebuffer.py
@@ -20,7 +20,7 @@ class TestCase(unittest.TestCase):
         rbo = self.ctx.renderbuffer((16, 16))
         self.ctx.framebuffer(rbo)
 
-    def test_framebuffer_get_color_attachment(self):
+    def test_framebuffer_get_color_attachments(self):
         rbo1 = self.ctx.renderbuffer((16, 16))
         rbo2 = self.ctx.renderbuffer((16, 16))
         rbo3 = self.ctx.renderbuffer((16, 16))
@@ -39,6 +39,16 @@ class TestCase(unittest.TestCase):
         self.assertIsInstance(fbo3.color_attachments[0], ModernGL.Renderbuffer)
         self.assertIsInstance(fbo3.color_attachments[1], ModernGL.Renderbuffer)
         self.assertIsInstance(fbo3.color_attachments[2], ModernGL.Renderbuffer)
+
+    def test_framebuffer_get_depth_attachment(self):
+        rbo1 = self.ctx.renderbuffer((16, 16))
+        rbo2 = self.ctx.depth_renderbuffer((16, 16))
+
+        fbo1 = self.ctx.framebuffer(rbo1)
+        fbo2 = self.ctx.framebuffer(rbo1, rbo2)
+
+        self.assertIsInstance(fbo1.depth_attachment, ModernGL.Renderbuffer)
+        self.assertIsInstance(fbo2.depth_attachment, ModernGL.Renderbuffer)
 
     def test_framebuffer_color_mask(self):
         fbo = self.ctx.framebuffer(self.ctx.renderbuffer((16, 16)))


### PR DESCRIPTION
### Description

The color_attachments were collected by the GC after the framebuffer creation.

This PR fixes [issue 103](https://github.com/cprogrammer1994/ModernGL/issues/103)

### List of changes

- **fixed** framebuffer `color_attachment` is not working.
- **added** tests for color and depth attachments.
