### PR TITLE
Fix alignment

### DIFF
--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -464,7 +464,11 @@ MGLTexture * MGLContext_texture(MGLContext * self, PyObject * args) {
 	if (samples) {
 		gl.TexImage2DMultisample(texture_target, samples, format, width, height, true);
 	} else {
+
+		// TODO: GL_PACK_ALIGNMENT or GL_UNPACK_ALIGNMENT not sure
+
 		gl.PixelStorei(GL_PACK_ALIGNMENT, alignment);
+		gl.PixelStorei(GL_UNPACK_ALIGNMENT, alignment);
 		gl.TexImage2D(texture_target, 0, format, width, height, 0, format, pixel_type, buffer_view.buf);
 		gl.TexParameteri(texture_target, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 		gl.TexParameteri(texture_target, GL_TEXTURE_MAG_FILTER, GL_LINEAR);

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -586,6 +586,11 @@ MGLTexture * MGLContext_depth_texture(MGLContext * self, PyObject * args) {
 	if (samples) {
 		gl.TexImage2DMultisample(texture_target, samples, GL_DEPTH_COMPONENT24, width, height, true);
 	} else {
+
+		// TODO: GL_PACK_ALIGNMENT or GL_UNPACK_ALIGNMENT not sure
+
+		gl.PixelStorei(GL_PACK_ALIGNMENT, alignment);
+		gl.PixelStorei(GL_UNPACK_ALIGNMENT, alignment);
 		gl.TexImage2D(texture_target, 0, GL_DEPTH_COMPONENT24, width, height, 0, GL_DEPTH_COMPONENT, pixel_type, buffer_view.buf);
 	}
 

--- a/src/Framebuffer.cpp
+++ b/src/Framebuffer.cpp
@@ -241,6 +241,10 @@ PyObject * MGLFramebuffer_read(MGLFramebuffer * self, PyObject * args) {
 
 	gl.BindFramebuffer(GL_FRAMEBUFFER, self->framebuffer_obj);
 	gl.ReadBuffer(GL_COLOR_ATTACHMENT0 + attachment);
+
+	// TODO: GL_PACK_ALIGNMENT or GL_UNPACK_ALIGNMENT not sure
+
+	gl.PixelStorei(GL_PACK_ALIGNMENT, alignment);
 	gl.PixelStorei(GL_UNPACK_ALIGNMENT, alignment);
 	gl.ReadPixels(x, y, width, height, format, type, data);
 	gl.BindFramebuffer(GL_FRAMEBUFFER, self->context->bound_framebuffer->framebuffer_obj);
@@ -333,6 +337,10 @@ PyObject * MGLFramebuffer_read_into(MGLFramebuffer * self, PyObject * args) {
 		gl.BindBuffer(GL_PIXEL_PACK_BUFFER, buffer->buffer_obj);
 		gl.BindFramebuffer(GL_FRAMEBUFFER, self->framebuffer_obj);
 		gl.ReadBuffer(GL_COLOR_ATTACHMENT0 + attachment);
+
+		// TODO: GL_PACK_ALIGNMENT or GL_UNPACK_ALIGNMENT not sure
+
+		gl.PixelStorei(GL_PACK_ALIGNMENT, alignment);
 		gl.PixelStorei(GL_UNPACK_ALIGNMENT, alignment);
 		gl.ReadPixels(x, y, width, height, format, type, (void *)write_offset);
 		gl.BindFramebuffer(GL_FRAMEBUFFER, self->context->bound_framebuffer->framebuffer_obj);
@@ -360,6 +368,10 @@ PyObject * MGLFramebuffer_read_into(MGLFramebuffer * self, PyObject * args) {
 
 		gl.BindFramebuffer(GL_FRAMEBUFFER, self->framebuffer_obj);
 		gl.ReadBuffer(GL_COLOR_ATTACHMENT0 + attachment);
+
+		// TODO: GL_PACK_ALIGNMENT or GL_UNPACK_ALIGNMENT not sure
+
+		gl.PixelStorei(GL_PACK_ALIGNMENT, alignment);
 		gl.PixelStorei(GL_UNPACK_ALIGNMENT, alignment);
 		gl.ReadPixels(x, y, width, height, format, type, ptr);
 		gl.BindFramebuffer(GL_FRAMEBUFFER, self->context->bound_framebuffer->framebuffer_obj);

--- a/src/Texture.cpp
+++ b/src/Texture.cpp
@@ -74,6 +74,9 @@ PyObject * MGLTexture_read(MGLTexture * self, PyObject * args) {
 	gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
 	gl.BindTexture(texture_target, self->texture_obj);
 
+	// TODO: GL_PACK_ALIGNMENT or GL_UNPACK_ALIGNMENT not sure
+
+	gl.PixelStorei(GL_PACK_ALIGNMENT, alignment);
 	gl.PixelStorei(GL_UNPACK_ALIGNMENT, alignment);
 	gl.GetTexImage(texture_target, 0, format, pixel_type, data);
 
@@ -126,6 +129,10 @@ PyObject * MGLTexture_read_into(MGLTexture * self, PyObject * args) {
 		gl.BindBuffer(GL_PIXEL_PACK_BUFFER, buffer->buffer_obj);
 		gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
 		gl.BindTexture(texture_target, self->texture_obj);
+
+		// TODO: GL_PACK_ALIGNMENT or GL_UNPACK_ALIGNMENT not sure
+
+		gl.PixelStorei(GL_PACK_ALIGNMENT, alignment);
 		gl.PixelStorei(GL_UNPACK_ALIGNMENT, alignment);
 		gl.GetTexImage(texture_target, 0, format, pixel_type, (void *)write_offset);
 		gl.BindBuffer(GL_PIXEL_PACK_BUFFER, 0);
@@ -151,6 +158,10 @@ PyObject * MGLTexture_read_into(MGLTexture * self, PyObject * args) {
 		const GLMethods & gl = self->context->gl;
 		gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
 		gl.BindTexture(texture_target, self->texture_obj);
+
+		// TODO: GL_PACK_ALIGNMENT or GL_UNPACK_ALIGNMENT not sure
+
+		gl.PixelStorei(GL_PACK_ALIGNMENT, alignment);
 		gl.PixelStorei(GL_UNPACK_ALIGNMENT, alignment);
 		gl.GetTexImage(texture_target, 0, format, pixel_type, ptr);
 
@@ -246,7 +257,11 @@ PyObject * MGLTexture_write(MGLTexture * self, PyObject * args) {
 		gl.BindBuffer(GL_PIXEL_UNPACK_BUFFER, buffer->buffer_obj);
 		gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
 		gl.BindTexture(texture_target, self->texture_obj);
+
+		// TODO: GL_PACK_ALIGNMENT or GL_UNPACK_ALIGNMENT not sure
+
 		gl.PixelStorei(GL_PACK_ALIGNMENT, alignment);
+		gl.PixelStorei(GL_UNPACK_ALIGNMENT, alignment);
 		gl.TexSubImage2D(texture_target, 0, x, y, width, height, format, pixel_type, 0);
 		gl.BindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
 
@@ -271,7 +286,10 @@ PyObject * MGLTexture_write(MGLTexture * self, PyObject * args) {
 		gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
 		gl.BindTexture(texture_target, self->texture_obj);
 
+		// TODO: GL_PACK_ALIGNMENT or GL_UNPACK_ALIGNMENT not sure
+
 		gl.PixelStorei(GL_PACK_ALIGNMENT, alignment);
+		gl.PixelStorei(GL_UNPACK_ALIGNMENT, alignment);
 		gl.TexSubImage2D(texture_target, 0, x, y, width, height, format, pixel_type, buffer_view.buf);
 
 		PyBuffer_Release(&buffer_view);

--- a/src/Texture.cpp
+++ b/src/Texture.cpp
@@ -78,6 +78,27 @@ PyObject * MGLTexture_read(MGLTexture * self, PyObject * args) {
 
 	gl.PixelStorei(GL_PACK_ALIGNMENT, alignment);
 	gl.PixelStorei(GL_UNPACK_ALIGNMENT, alignment);
+
+	// To determine the required size of pixels, use glGetTexLevelParameter to determine
+	// the dimensions of the internal texture image, then scale the required number of pixels
+	// by the storage required for each pixel, based on format and type. Be sure to take the
+	// pixel storage parameters into account, especially GL_PACK_ALIGNMENT.
+
+	// int pack = 0;
+	// gl.GetIntegerv(GL_PACK_ALIGNMENT, &pack);
+	// printf("GL_PACK_ALIGNMENT: %d\n", pack);
+
+	// glGetTexLevelParameter with argument GL_TEXTURE_WIDTH
+	// glGetTexLevelParameter with argument GL_TEXTURE_HEIGHT
+	// glGetTexLevelParameter with argument GL_TEXTURE_INTERNAL_FORMAT
+
+	// int level_width = 0;
+	// int level_height = 0;
+	// gl.GetTexLevelParameteriv(texture_target, 0, GL_TEXTURE_WIDTH, &level_width);
+	// gl.GetTexLevelParameteriv(texture_target, 0, GL_TEXTURE_HEIGHT, &level_height);
+	// printf("level_width: %d\n", level_width);
+	// printf("level_height: %d\n", level_height);
+
 	gl.GetTexImage(texture_target, 0, format, pixel_type, data);
 
 	return result;

--- a/tests/basic/test_simple_texture.py
+++ b/tests/basic/test_simple_texture.py
@@ -60,6 +60,88 @@ class TestCase(unittest.TestCase):
         tex.swizzle = '01RG'
         self.assertEqual(tex.swizzle, '01RG')
 
+    def test_texture_read(self):
+        pixels = b'\x10\x20\x30' * 8 * 8
+        tex = self.ctx.texture((8, 8), 3, pixels)
+        self.assertEqual(tex.read(), pixels)
+
+    def test_texture_read_into(self):
+        pixels = b'\x10\x20\x30' * 8 * 8
+        tex = self.ctx.texture((8, 8), 3, pixels)
+        buf = bytearray(8 * 8 * 3)
+        tex.read_into(buf)
+        self.assertEqual(bytes(buf), pixels)
+
+    def test_texture_read_into_pbo(self):
+        pixels = b'\x10\x20\x30' * 8 * 8
+        tex = self.ctx.texture((8, 8), 3, pixels)
+        buf = self.ctx.buffer(reserve=8 * 8 * 3)
+
+        tex.read_into(buf)
+        self.assertEqual(buf.read(), pixels)
+
+    def test_texture_write_1(self):
+        pixels1 = b'\x00\x00\x00' * 8 * 8
+        pixels2 = b'\xff\xff\xff' * 8 * 8
+
+        tex = self.ctx.texture((8, 8), 3, pixels1)
+        self.assertEqual(tex.read(), pixels1)
+
+        tex.write(pixels2)
+        self.assertEqual(tex.read(), pixels2)
+
+    def test_texture_write_2(self):
+        pixels1 = b'\x00\x00\x00' * 8 * 8
+        pixels2 = b'\xff\xff\xff' * 6 * 6
+        pixels3 = b'\x10\x20\x30'
+
+        tex = self.ctx.texture((8, 8), 3)
+
+        tex.write(pixels1, viewport=(0, 0, 8, 8))
+        tex.write(pixels2, viewport=(1, 1, 6, 6))
+        tex.write(pixels3, viewport=(2, 4, 1, 1))
+
+        def pixel(x, y):
+            if x == 2 and y == 4:
+                return b'\x10\x20\x30'
+
+            if x == 0 or y == 0 or x == 7 or y == 7:
+                return b'\x00\x00\x00'
+
+            return b'\xff\xff\xff'
+
+        expectation = b''.join(pixel(x, y) for y in range(8) for x in range(8))
+        self.assertEqual(tex.read(), expectation)
+
+    def test_texture_alignment_1(self):
+        tex = self.ctx.texture((3, 3), 3)
+        self.assertEqual(len(tex.read(alignment=1)), 27)
+
+    def test_texture_alignment_2(self):
+        tex = self.ctx.texture((3, 3), 3)
+        self.assertEqual(len(tex.read(alignment=2)), 30)
+
+    def test_texture_alignment_3(self):
+        tex = self.ctx.texture((3, 3), 3)
+        self.assertEqual(len(tex.read(alignment=4)), 36)
+
+    def test_texture_alignment_4(self):
+        tex = self.ctx.texture((3, 3), 3)
+        self.assertEqual(len(tex.read(alignment=8)), 48)
+
+    def test_texture_alignment_5(self):
+        pixels = b'\x80\x90\xA0\x80\x90\xA0\x80\x90\xA0\x80\x90\xA0'
+        tex = self.ctx.texture((2, 2), 3, pixels, alignment=1)
+        self.assertEqual(tex.read(alignment=1), pixels)
+
+    def test_texture_alignment_6(self):
+        pixels = b'\x80\x90\xA0\x80\x90\xA0\x00\x00\x80\x90\xA0\x80\x90\xA0\x00\x00'
+        tex = self.ctx.texture((2, 2), 3, pixels, alignment=4)
+        result = tex.read(alignment=4)
+        self.assertEqual(result[0 : 6], b'\x80\x90\xA0\x80\x90\xA0')
+        self.assertEqual(result[8 : 14], b'\x80\x90\xA0\x80\x90\xA0')
+
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### List of changes

- **fixed** texture alignment

### Style for python files:

- Please use 4 spaces (not tabs).
- Please follow the pep8 style guide.
