### PR TITLE
3D textures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- 3D texture support (`Texture3D` class and Context `texture3d` method)
+
 ### Removed
 - Unused texture's `read` method's `viewport` parameter
 

--- a/ModernGL/__init__.py
+++ b/ModernGL/__init__.py
@@ -45,7 +45,7 @@ from .vertex_arrays import (
 from .context import Context, create_context, create_standalone_context
 from .buffers import Buffer, BufferAccess, detect_format
 from .programs import ComputeShader, Shader, Program
-from .textures import Texture
+from .textures import Texture, Texture3D
 from .renderbuffers import Renderbuffer
 from .framebuffers import Framebuffer
 
@@ -62,7 +62,7 @@ __all__ = [
     'Uniform', 'UniformMap', 'UniformBlock', 'UniformBlockMap',
     'Varying', 'VaryingMap', 'Attribute', 'AttributeMap',
     'Program', 'ProgramStage', 'Shader', 'ComputeShader',
-    'Texture', 'Framebuffer', 'Renderbuffer',
+    'Texture', 'Texture3D', 'Framebuffer', 'Renderbuffer',
     'VertexArray', 'VertexArrayAttribute',
     'Buffer', 'BufferAccess',
     'Context',

--- a/ModernGL/context.py
+++ b/ModernGL/context.py
@@ -334,7 +334,7 @@ class Context:
 
         return Texture.new(self.mglo.texture(size, components, data, samples, alignment, floats))
 
-    def texture3D(self, size, components, data=None, *, alignment=1, floats=False) -> Texture3D:
+    def texture3d(self, size, components, data=None, *, alignment=1, floats=False) -> Texture3D:
         '''
             Create a :py:class:`Texture3D`.
 
@@ -351,7 +351,7 @@ class Context:
                 Texture3D: texture
         '''
 
-        return Texture3D.new(self.mglo.texture3D(size, components, data, alignment, floats))
+        return Texture3D.new(self.mglo.texture3d(size, components, data, alignment, floats))
 
     def depth_texture(self, size, data=None, *, samples=0, alignment=4) -> Texture:
         '''

--- a/ModernGL/context.py
+++ b/ModernGL/context.py
@@ -15,7 +15,7 @@ from .common import InvalidObject
 from .buffers import Buffer, detect_format
 from .programs import ComputeShader, Shader, Program
 from .vertex_arrays import VertexArray
-from .textures import Texture
+from .textures import Texture, Texture3D
 from .renderbuffers import Renderbuffer
 from .framebuffers import Framebuffer
 
@@ -324,6 +324,25 @@ class Context:
         '''
 
         return Texture.new(self.mglo.texture(size, components, data, samples, alignment, floats))
+
+    def texture3D(self, size, components, data=None, *, alignment=1, floats=False) -> Texture3D:
+        '''
+            Create a :py:class:`Texture3D`.
+
+            Args:
+                size (tuple): The width, height and depth of the texture.
+                components (int): The number of components 1, 2, 3 or 4.
+                data (bytes): Content of the texture.
+
+            Keyword Args:
+                alignment (int): The byte alignment 1, 2, 4 or 8.
+                floats (bool): Use floating point precision.
+
+            Returns:
+                Texture3D: texture
+        '''
+
+        return Texture3D.new(self.mglo.texture(size, components, data, alignment, floats))
 
     def depth_texture(self, size, data=None, *, samples=0, alignment=4) -> Texture:
         '''

--- a/ModernGL/context.py
+++ b/ModernGL/context.py
@@ -342,7 +342,7 @@ class Context:
                 Texture3D: texture
         '''
 
-        return Texture3D.new(self.mglo.texture(size, components, data, alignment, floats))
+        return Texture3D.new(self.mglo.texture3D(size, components, data, alignment, floats))
 
     def depth_texture(self, size, data=None, *, samples=0, alignment=4) -> Texture:
         '''

--- a/ModernGL/textures.py
+++ b/ModernGL/textures.py
@@ -247,6 +247,12 @@ class Texture3D:
     def __repr__(self):
         return '<Texture3D: %d>' % self.glo
 
+    def __eq__(self, other):
+        return self.mglo is other.mglo
+
+    def __ne__(self, other):
+        return self.mglo is not other.mglo
+
     @property
     def repeat_x(self) -> bool:
         '''
@@ -356,7 +362,7 @@ class Texture3D:
 
         return self.mglo.glo
 
-    def read(self, viewport=None, *, alignment=1) -> bytes:
+    def read(self, *, alignment=1) -> bytes:
         '''
             Read the content of the texture into a buffer.
 
@@ -371,9 +377,9 @@ class Texture3D:
                 bytes: the pixels
         '''
 
-        return self.mglo.read(viewport, alignment)
+        return self.mglo.read(alignment)
 
-    def read_into(self, buffer, viewport=None, *, alignment=1, write_offset=0) -> None:
+    def read_into(self, buffer, *, alignment=1, write_offset=0) -> None:
         '''
             Read the content of the texture into a buffer.
 
@@ -389,7 +395,7 @@ class Texture3D:
         if isinstance(buffer, Buffer):
             buffer = buffer.mglo
 
-        return self.mglo.read_into(buffer, viewport, alignment, write_offset)
+        return self.mglo.read_into(buffer, alignment, write_offset)
 
     def write(self, data, viewport=None, *, alignment=1) -> None:
         '''

--- a/ModernGL/textures.py
+++ b/ModernGL/textures.py
@@ -214,3 +214,216 @@ class Texture:
 
         self.mglo.release()
         self.__class__ = InvalidObject
+
+
+class Texture3D:
+    '''
+        A Texture is an OpenGL object that contains one or more images that all
+        have the same image format. A texture can be used in two ways. It can
+        be the source of a texture access from a Shader, or it can be used
+        as a render target.
+
+        A Texture3D object cannot be instantiated directly, it requires a context.
+        Use :py:meth:`Context.texture_3d` to create one.
+    '''
+
+    __slots__ = ['mglo']
+
+    @staticmethod
+    def new(obj):
+        '''
+            For internal use only.
+        '''
+
+        res = Texture.__new__(Texture)
+        res.mglo = obj
+        return res
+
+    def __init__(self):
+        self.mglo = None
+        raise NotImplementedError()
+
+    def __repr__(self):
+        return '<Texture3D: %d>' % self.glo
+
+    @property
+    def repeat_x(self) -> bool:
+        '''
+            bool: The repeat_x of the texture.
+        '''
+
+        return self.mglo.repeat_x
+
+    @repeat_x.setter
+    def repeat_x(self, value):
+        self.mglo.repeat_x = value
+
+    @property
+    def repeat_y(self) -> bool:
+        '''
+            bool: The repeat_y of the texture.
+        '''
+
+        return self.mglo.repeat_y
+
+    @repeat_y.setter
+    def repeat_y(self, value):
+        self.mglo.repeat_y = value
+
+    @property
+    def repeat_z(self) -> bool:
+        '''
+            bool: The repeat_z of the texture.
+        '''
+
+        return self.mglo.repeat_z
+
+    @repeat_z.setter
+    def repeat_z(self, value):
+        self.mglo.repeat_z = value
+
+    @property
+    def filter(self) -> TextureFilter:
+        '''
+            TextureFilter: The filter of the texture.
+        '''
+
+        return self.mglo.filter
+
+    @filter.setter
+    def filter(self, value):
+        self.mglo.filter = value.mglo
+
+    @property
+    def swizzle(self) -> str:
+        '''
+            str: The swizzle of the texture.
+        '''
+
+        return self.mglo.swizzle
+
+    @swizzle.setter
+    def swizzle(self, value):
+        self.mglo.swizzle = value
+
+    @property
+    def width(self) -> int:
+        '''
+            int: The width of the texture.
+        '''
+
+        return self.mglo.width
+
+    @property
+    def height(self) -> int:
+        '''
+            int: The height of the texture.
+        '''
+
+        return self.mglo.height
+
+    @property
+    def depth(self) -> int:
+        '''
+            int: The depth of the texture.
+        '''
+
+        return self.mglo.depth
+
+    @property
+    def size(self) -> tuple:
+        '''
+            tuple: The size of the texture.
+        '''
+
+        return (self.mglo.width, self.mglo.height, self.mglo.depth)
+
+    @property
+    def components(self) -> int:
+        '''
+            int: The number of components of the texture.
+        '''
+
+        return self.mglo.components
+
+    @property
+    def glo(self) -> int:
+        '''
+            int: The internal OpenGL object.
+            This values is provided for debug purposes only.
+        '''
+
+        return self.mglo.glo
+
+    def read(self, viewport=None, *, alignment=1) -> bytes:
+        '''
+            Read the content of the texture into a buffer.
+
+            Args:
+                buffer (bytearray): The buffer that will receive the pixels.
+                viewport (tuple): The viewport.
+
+            Keyword Args:
+                alignment (int): The byte alignment of the pixels.
+
+            Returns:
+                bytes: the pixels
+        '''
+
+        return self.mglo.read(viewport, alignment)
+
+    def read_into(self, buffer, viewport=None, *, alignment=1, write_offset=0) -> None:
+        '''
+            Read the content of the texture into a buffer.
+
+            Args:
+                buffer (bytearray): The buffer that will receive the pixels.
+                viewport (tuple): The viewport.
+
+            Keyword Args:
+                alignment (int): The byte alignment of the pixels.
+                write_offset (int): The write offset.
+        '''
+
+        if isinstance(buffer, Buffer):
+            buffer = buffer.mglo
+
+        return self.mglo.read_into(buffer, viewport, alignment, write_offset)
+
+    def write(self, data, viewport=None, *, alignment=1) -> None:
+        '''
+            Update the content of the texture.
+        '''
+
+        if isinstance(data, Buffer):
+            data = data.mglo
+
+        self.mglo.write(data, viewport, alignment)
+
+    def build_mipmaps(self, base=0, max_level=1000) -> None:
+        '''
+            Generate mipmaps.
+        '''
+
+        self.mglo.build_mipmaps(base, max_level)
+
+    def use(self, location=0) -> None:
+        '''
+            Bind the texture.
+
+            Args:
+                location (int): The texture location.
+                    Same as the integer value that is used for sampler3D
+                    uniforms in the shaders. The value ``0`` will bind the
+                    texture to the ``GL_TEXTURE0`` binding point.
+        '''
+
+        self.mglo.use(location)
+
+    def release(self) -> None:
+        '''
+            Release the ModernGL object.
+        '''
+
+        self.mglo.release()
+        self.__class__ = InvalidObject

--- a/ModernGL/textures.py
+++ b/ModernGL/textures.py
@@ -225,7 +225,7 @@ class Texture3D:
         as a render target.
 
         A Texture3D object cannot be instantiated directly, it requires a context.
-        Use :py:meth:`Context.texture_3d` to create one.
+        Use :py:meth:`Context.texture3d` to create one.
     '''
 
     __slots__ = ['mglo']

--- a/examples/GLWindow/brick_texture_3d.py
+++ b/examples/GLWindow/brick_texture_3d.py
@@ -1,0 +1,108 @@
+import struct
+from math import cos, sin, pi
+from random import randrange
+
+import GLWindow
+from pyrr import Matrix44
+
+import ModernGL
+
+
+def create_brick_texture(size):
+    result = bytearray()
+
+    for z in range(size[2]):
+        for y in range(size[1]):
+            for x in range(size[0]):
+
+                if x != size[0] - 1 and y != size[1] - 1 and z != size[2] - 1:
+                    n1, n2, n3 = randrange(0, 16), randrange(0, 16), randrange(0, 16)
+                    result += struct.pack('BBB', 220 + n1, 31 + n2, 0 + n3)
+
+                else:
+                    n = randrange(0, 16)
+                    result += struct.pack('BBB', 240 - n, 240 - n, 240 - n)
+
+    return bytes(result)
+
+
+wnd = GLWindow.create_window()
+ctx = ModernGL.create_context()
+
+prog = ctx.program([
+    ctx.vertex_shader('''
+        #version 330
+
+        uniform mat4 Mvp;
+        uniform vec3 TextureSize;
+
+        in vec3 vert;
+        out vec3 v_text;
+
+        void main() {
+            v_text = vert * 100.0 / TextureSize;
+            gl_Position = Mvp * vec4(vert, 1.0);
+        }
+    '''),
+    ctx.fragment_shader('''
+        #version 330
+
+        uniform sampler3D Texture;
+
+        in vec3 v_text;
+        out vec4 color;
+
+        void main() {
+            color = texture(Texture, v_text);
+        }
+    '''),
+])
+
+mvp = prog.uniforms['Mvp']
+texture_size = prog.uniforms['TextureSize']
+
+vbo = ctx.buffer(struct.pack(
+    '36f',
+
+    0.0, 0.0, 0.0,
+    2.0, 0.0, 0.0,
+    0.0, 2.0, 0.0,
+
+    0.0, 0.0, 0.0,
+    2.0, 0.0, 0.0,
+    0.0, 0.0, 2.0,
+
+    0.0, 0.0, 0.0,
+    0.0, 2.0, 0.0,
+    0.0, 0.0, 2.0,
+
+    2.0, 0.0, 0.0,
+    0.0, 2.0, 0.0,
+    0.0, 0.0, 2.0,
+))
+
+vao = ctx.simple_vertex_array(prog, vbo, ['vert'])
+
+size = (20, 16, 8)
+texture_size.value = size
+texure = ctx.texture3d(size, 3, create_brick_texture(size))
+texure.filter = ModernGL.NEAREST
+texure.use()
+
+ctx.enable(ModernGL.DEPTH_TEST)
+
+while wnd.update():
+    angle = wnd.time
+    width, height = wnd.size
+    proj = Matrix44.perspective_projection(45.0, width / height, 0.1, 1000.0)
+    lookat = Matrix44.look_at(
+        (cos(angle) * 5.0, sin(angle) * 5.0, 2.5),
+        (0.0, 0.0, 0.5),
+        (0.0, 0.0, 1.0),
+    )
+
+    mvp.write((proj * lookat).astype('float32').tobytes())
+
+    ctx.viewport = wnd.viewport
+    ctx.clear(0.9, 0.9, 0.9)
+    vao.render()

--- a/examples/GLWindow/requirements.txt
+++ b/examples/GLWindow/requirements.txt
@@ -1,2 +1,3 @@
 GLWindow
 ModernGL
+pyrr>=0.8.4

--- a/examples/GLWindow/texture3D_example.py
+++ b/examples/GLWindow/texture3D_example.py
@@ -39,8 +39,8 @@ prog = ctx.program([
 data = bytes()
 
 for i in range(11):
-    data += struct.pack('5f', i / 10.0 - 0.5, 0.9, random.random(), random.random(), random.random())
-    data += struct.pack('5f', i / 10.0 - 0.5, -0.9, random.random(), random.random(), random.random())
+    data += struct.pack('5f', i / 10.0 - 0.5, 0.2, random.random(), random.random(), random.random())
+    data += struct.pack('5f', i / 10.0 - 0.5, -0.2, random.random(), random.random(), random.random())
 
 vbo = ctx.buffer(data)
 
@@ -62,4 +62,4 @@ texture.use()
 while wnd.update():
     ctx.viewport = wnd.viewport
     ctx.clear(0.9, 0.9, 0.9)
-    vao.render()
+    vao.render(ModernGL.TRIANGLE_STRIP)

--- a/examples/GLWindow/texture3D_example.py
+++ b/examples/GLWindow/texture3D_example.py
@@ -1,0 +1,65 @@
+import struct
+import random
+
+import GLWindow
+import ModernGL
+
+from PIL import Image
+
+wnd = GLWindow.create_window()
+ctx = ModernGL.create_context()
+
+prog = ctx.program([
+    ctx.vertex_shader('''
+        #version 330
+
+        in vec2 vert;
+        in vec3 tex_coord;
+        out vec3 v_tex_coord;
+
+        void main() {
+            gl_Position = vec4(vert, 0.0, 1.0);
+            v_tex_coord = tex_coord;
+        }
+    '''),
+    ctx.fragment_shader('''
+        #version 330
+
+        uniform sampler3D Texture;
+
+        in vec3 v_tex_coord;
+        out vec4 color;
+
+        void main() {
+            color = vec4(texture(Texture, v_tex_coord).rgb, 1.0);
+        }
+    '''),
+])
+
+data = bytes()
+
+for i in range(11):
+    data += struct.pack('5f', i / 10.0 - 0.5, 0.9, random.random(), random.random(), random.random())
+    data += struct.pack('5f', i / 10.0 - 0.5, -0.9, random.random(), random.random(), random.random())
+
+vbo = ctx.buffer(data)
+
+vao = ctx.simple_vertex_array(prog, vbo, ['vert', 'tex_coord'])
+
+pixels = bytes()
+
+for i in range(4):
+    for j in range(4):
+        for k in range(4):
+            r = int(i * 255 / 3)
+            g = int(j * 255 / 3)
+            b = int(k * 255 / 3)
+            pixels += struct.pack('3B', r, g, b)
+
+texture = ctx.texture3D((4, 4, 4), 3, pixels)
+texture.use()
+
+while wnd.update():
+    ctx.viewport = wnd.viewport
+    ctx.clear(0.9, 0.9, 0.9)
+    vao.render()

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -540,7 +540,11 @@ MGLTexture3D * MGLContext_texture3D(MGLContext * self, PyObject * args) {
 	Py_buffer buffer_view;
 
 	if (data != Py_None) {
-		PyObject_GetBuffer(data, &buffer_view, PyBUF_SIMPLE);
+		int get_buffer = PyObject_GetBuffer(data, &buffer_view, PyBUF_SIMPLE);
+		if (get_buffer < 0) {
+			MGLError_Set("data (%s) does not support buffer interface", Py_TYPE(data)->tp_name);
+			return 0;
+		}
 	} else {
 		buffer_view.len = expected_size;
 		buffer_view.buf = 0;

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -1490,6 +1490,7 @@ PyMethodDef MGLContext_tp_methods[] = {
 
 	{"buffer", (PyCFunction)MGLContext_buffer, METH_VARARGS, 0},
 	{"texture", (PyCFunction)MGLContext_texture, METH_VARARGS, 0},
+	{"texture3D", (PyCFunction)MGLContext_texture3D, METH_VARARGS, 0},
 	{"depth_texture", (PyCFunction)MGLContext_depth_texture, METH_VARARGS, 0},
 	{"vertex_array", (PyCFunction)MGLContext_vertex_array, METH_VARARGS, 0},
 	{"program", (PyCFunction)MGLContext_program, METH_VARARGS, 0},

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -495,7 +495,7 @@ MGLTexture * MGLContext_texture(MGLContext * self, PyObject * args) {
 	return texture;
 }
 
-MGLTexture3D * MGLContext_texture3D(MGLContext * self, PyObject * args) {
+MGLTexture3D * MGLContext_texture3d(MGLContext * self, PyObject * args) {
 	int width;
 	int height;
 	int depth;
@@ -1511,7 +1511,7 @@ PyMethodDef MGLContext_tp_methods[] = {
 
 	{"buffer", (PyCFunction)MGLContext_buffer, METH_VARARGS, 0},
 	{"texture", (PyCFunction)MGLContext_texture, METH_VARARGS, 0},
-	{"texture3D", (PyCFunction)MGLContext_texture3D, METH_VARARGS, 0},
+	{"texture3d", (PyCFunction)MGLContext_texture3d, METH_VARARGS, 0},
 	{"depth_texture", (PyCFunction)MGLContext_depth_texture, METH_VARARGS, 0},
 	{"vertex_array", (PyCFunction)MGLContext_vertex_array, METH_VARARGS, 0},
 	{"program", (PyCFunction)MGLContext_program, METH_VARARGS, 0},

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -580,6 +580,7 @@ MGLTexture3D * MGLContext_texture3d(MGLContext * self, PyObject * args) {
 	gl.BindTexture(GL_TEXTURE_3D, texture->texture_obj);
 
 	gl.PixelStorei(GL_PACK_ALIGNMENT, alignment);
+	gl.PixelStorei(GL_UNPACK_ALIGNMENT, alignment);
 	gl.TexImage3D(GL_TEXTURE_3D, 0, format, width, height, depth, 0, format, pixel_type, buffer_view.buf);
 	gl.TexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 	gl.TexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -508,6 +508,7 @@ MGLTexture3D * MGLContext_texture3D(MGLContext * self, PyObject * args) {
 		"(III)IOIp",
 		&width,
 		&height,
+		&depth,
 		&components,
 		&data,
 		&alignment,

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -4,6 +4,7 @@
 #include "Buffer.hpp"
 #include "ComputeShader.hpp"
 #include "Texture.hpp"
+#include "Texture3D.hpp"
 #include "VertexArray.hpp"
 #include "Program.hpp"
 #include "Shader.hpp"
@@ -482,6 +483,114 @@ MGLTexture * MGLContext_texture(MGLContext * self, PyObject * args) {
 
 	texture->repeat_x = true;
 	texture->repeat_y = true;
+
+	Py_INCREF(self);
+	texture->context = self;
+
+	Py_INCREF(texture);
+	return texture;
+}
+
+MGLTexture3D * MGLContext_texture3D(MGLContext * self, PyObject * args) {
+	int width;
+	int height;
+	int depth;
+
+	int components;
+
+	PyObject * data;
+
+	int alignment;
+	int floats;
+
+	int args_ok = PyArg_ParseTuple(
+		args,
+		"(III)IOIp",
+		&width,
+		&height,
+		&components,
+		&data,
+		&alignment,
+		&floats
+	);
+
+	if (!args_ok) {
+		return 0;
+	}
+
+	if (components < 1 || components > 4) {
+		MGLError_Set("the components must be 1, 2, 3 or 4");
+		return 0;
+	}
+
+	if (alignment != 1 && alignment != 2 && alignment != 4 && alignment != 8) {
+		MGLError_Set("the alignment must be 1, 2, 4 or 8");
+		return 0;
+	}
+
+	int expected_size = width * components * (floats ? 4 : 1);
+	expected_size = (expected_size + alignment - 1) / alignment * alignment;
+	expected_size = expected_size * height * depth;
+
+	Py_buffer buffer_view;
+
+	if (data != Py_None) {
+		PyObject_GetBuffer(data, &buffer_view, PyBUF_SIMPLE);
+	} else {
+		buffer_view.len = expected_size;
+		buffer_view.buf = 0;
+	}
+
+	if (buffer_view.len != expected_size) {
+		MGLError_Set("data size mismatch %d != %d", buffer_view.len, expected_size);
+		if (data != Py_None) {
+			PyBuffer_Release(&buffer_view);
+		}
+		return 0;
+	}
+
+	const int formats[] = {0, GL_RED, GL_RG, GL_RGB, GL_RGBA};
+
+	int pixel_type = floats ? GL_FLOAT : GL_UNSIGNED_BYTE;
+	int format = formats[components];
+
+	const GLMethods & gl = self->gl;
+
+	MGLTexture3D * texture = MGLTexture3D_New();
+
+	texture->texture_obj = 0;
+	gl.GenTextures(1, (GLuint *)&texture->texture_obj);
+
+	if (!texture->texture_obj) {
+		MGLError_Set("cannot create texture");
+		Py_DECREF(texture);
+		return 0;
+	}
+
+	gl.ActiveTexture(GL_TEXTURE0 + self->default_texture_unit);
+	gl.BindTexture(GL_TEXTURE_3D, texture->texture_obj);
+
+	gl.PixelStorei(GL_PACK_ALIGNMENT, alignment);
+	gl.TexImage3D(GL_TEXTURE_3D, 0, format, width, height, depth, 0, format, pixel_type, buffer_view.buf);
+	gl.TexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+	gl.TexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+
+	if (data != Py_None) {
+		PyBuffer_Release(&buffer_view);
+	}
+
+	texture->width = width;
+	texture->height = height;
+	texture->depth = depth;
+	texture->components = components;
+	texture->floats = floats ? true : false;
+
+	Py_INCREF(MGL_LINEAR);
+	texture->filter = MGL_LINEAR;
+
+	texture->repeat_x = true;
+	texture->repeat_y = true;
+	texture->repeat_z = true;
 
 	Py_INCREF(self);
 	texture->context = self;

--- a/src/ModernGL.cpp
+++ b/src/ModernGL.cpp
@@ -15,6 +15,7 @@
 #include "Subroutine.hpp"
 #include "SubroutineUniform.hpp"
 #include "Texture.hpp"
+#include "Texture3D.hpp"
 #include "TextureFilter.hpp"
 #include "Uniform.hpp"
 #include "UniformBlock.hpp"
@@ -275,6 +276,17 @@ bool MGL_InitializeModule(PyObject * module) {
 		Py_INCREF(&MGLTexture_Type);
 
 		PyModule_AddObject(module, "Texture", (PyObject *)&MGLTexture_Type);
+	}
+
+	{
+		if (PyType_Ready(&MGLTexture3D_Type) < 0) {
+			PyErr_Format(PyExc_ImportError, "Cannot register Texture3D in %s (%s:%d)", __FUNCTION__, __FILE__, __LINE__);
+			return false;
+		}
+
+		Py_INCREF(&MGLTexture3D_Type);
+
+		PyModule_AddObject(module, "Texture3D", (PyObject *)&MGLTexture3D_Type);
 	}
 
 	{

--- a/src/Texture3D.cpp
+++ b/src/Texture3D.cpp
@@ -34,13 +34,11 @@ int MGLTexture3D_tp_init(MGLTexture3D * self, PyObject * args, PyObject * kwargs
 }
 
 PyObject * MGLTexture3D_read(MGLTexture3D * self, PyObject * args) {
-	PyObject * viewport;
 	int alignment;
 
 	int args_ok = PyArg_ParseTuple(
 		args,
-		"OI",
-		&viewport,
+		"I",
 		&alignment
 	);
 
@@ -58,51 +56,9 @@ PyObject * MGLTexture3D_read(MGLTexture3D * self, PyObject * args) {
 		return 0;
 	}
 
-	int x = 0;
-	int y = 0;
-	int z = 0;
-	int width = self->width;
-	int height = self->height;
-	int depth = self->depth;
-
-	if (viewport != Py_None) {
-		if (Py_TYPE(viewport) != &PyTuple_Type) {
-			MGLError_Set("the viewport must be a tuple not %s", Py_TYPE(viewport)->tp_name);
-			return 0;
-		}
-
-		if (PyTuple_GET_SIZE(viewport) == 6) {
-
-			x = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 0));
-			y = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 1));
-			z = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 2));
-			width = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 3));
-			height = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 4));
-			depth = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 5));
-
-		} else if (PyTuple_GET_SIZE(viewport) == 3) {
-
-			width = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 0));
-			height = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 1));
-			depth = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 2));
-
-		} else {
-
-			MGLError_Set("the viewport size %d is invalid", PyTuple_GET_SIZE(viewport));
-			return 0;
-
-		}
-
-		if (PyErr_Occurred()) {
-			MGLError_Set("wrong values in the viewport");
-			return 0;
-		}
-
-	}
-
-	int expected_size = width * self->components * (self->floats ?  4 : 1);
+	int expected_size = self->width * self->components * (self->floats ?  4 : 1);
 	expected_size = (expected_size + alignment - 1) / alignment * alignment;
-	expected_size = expected_size * height * depth;
+	expected_size = expected_size * self->height * self->depth;
 
 	PyObject * result = PyBytes_FromStringAndSize(0, expected_size);
 	char * data = PyBytes_AS_STRING(result);
@@ -125,15 +81,13 @@ PyObject * MGLTexture3D_read(MGLTexture3D * self, PyObject * args) {
 
 PyObject * MGLTexture3D_read_into(MGLTexture3D * self, PyObject * args) {
 	PyObject * data;
-	PyObject * viewport;
 	int alignment;
-	int write_offset; // TODO: unused
+	Py_ssize_t write_offset;
 
 	int args_ok = PyArg_ParseTuple(
 		args,
-		"OOII",
+		"OIn",
 		&data,
-		&viewport,
 		&alignment,
 		&write_offset
 	);
@@ -152,51 +106,9 @@ PyObject * MGLTexture3D_read_into(MGLTexture3D * self, PyObject * args) {
 		return 0;
 	}
 
-	int x = 0;
-	int y = 0;
-	int z = 0;
-	int width = self->width;
-	int height = self->height;
-	int depth = self->depth;
-
-	if (viewport != Py_None) {
-		if (Py_TYPE(viewport) != &PyTuple_Type) {
-			MGLError_Set("the viewport must be a tuple not %s", Py_TYPE(viewport)->tp_name);
-			return 0;
-		}
-
-		if (PyTuple_GET_SIZE(viewport) == 6) {
-
-			x = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 0));
-			y = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 1));
-			z = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 2));
-			width = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 3));
-			height = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 4));
-			depth = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 5));
-
-		} else if (PyTuple_GET_SIZE(viewport) == 3) {
-
-			width = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 0));
-			height = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 1));
-			depth = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 1));
-
-		} else {
-
-			MGLError_Set("the viewport size %d is invalid", PyTuple_GET_SIZE(viewport));
-			return 0;
-
-		}
-
-		if (PyErr_Occurred()) {
-			MGLError_Set("wrong values in the viewport");
-			return 0;
-		}
-
-	}
-
-	int expected_size = width * self->components * (self->floats ?  4 : 1);
+	int expected_size = self->width * self->components * (self->floats ? 4 : 1);
 	expected_size = (expected_size + alignment - 1) / alignment * alignment;
-	expected_size = expected_size * height * depth;
+	expected_size = expected_size * self->height * self->depth;
 
 	const int formats[] = {0, GL_RED, GL_RG, GL_RGB, GL_RGBA};
 
@@ -321,7 +233,7 @@ PyObject * MGLTexture3D_write(MGLTexture3D * self, PyObject * args) {
 
 	}
 
-	int expected_size = width * self->components * (self->floats ?  4 : 1);
+	int expected_size = width * self->components * (self->floats ? 4 : 1);
 	expected_size = (expected_size + alignment - 1) / alignment * alignment;
 	expected_size = expected_size * height * depth;
 

--- a/src/Texture3D.cpp
+++ b/src/Texture3D.cpp
@@ -257,7 +257,11 @@ PyObject * MGLTexture3D_write(MGLTexture3D * self, PyObject * args) {
 
 	} else {
 
-		PyObject_GetBuffer(data, &buffer_view, PyBUF_SIMPLE);
+		int get_buffer = PyObject_GetBuffer(data, &buffer_view, PyBUF_SIMPLE);
+		if (get_buffer < 0) {
+			MGLError_Set("data (%s) does not support buffer interface", Py_TYPE(data)->tp_name);
+			return 0;
+		}
 
 		if (buffer_view.len != expected_size) {
 			MGLError_Set("data size mismatch %d != %d", buffer_view.len, expected_size);

--- a/src/Texture3D.cpp
+++ b/src/Texture3D.cpp
@@ -1,0 +1,754 @@
+#include "Texture3D.hpp"
+
+#include "Error.hpp"
+#include "InvalidObject.hpp"
+#include "Buffer.hpp"
+
+#include "InlineMethods.hpp"
+
+PyObject * MGLTexture3D_tp_new(PyTypeObject * type, PyObject * args, PyObject * kwargs) {
+	MGLTexture3D * self = (MGLTexture3D *)type->tp_alloc(type, 0);
+
+	#ifdef MGL_VERBOSE
+	printf("MGLTexture3D_tp_new %p\n", self);
+	#endif
+
+	if (self) {
+	}
+
+	return (PyObject *)self;
+}
+
+void MGLTexture3D_tp_dealloc(MGLTexture3D * self) {
+
+	#ifdef MGL_VERBOSE
+	printf("MGLTexture3D_tp_dealloc %p\n", self);
+	#endif
+
+	MGLTexture3D_Type.tp_free((PyObject *)self);
+}
+
+int MGLTexture3D_tp_init(MGLTexture3D * self, PyObject * args, PyObject * kwargs) {
+	MGLError_Set("cannot create mgl.Texture3D manually");
+	return -1;
+}
+
+PyObject * MGLTexture3D_read(MGLTexture3D * self, PyObject * args) {
+	PyObject * viewport;
+	int alignment;
+
+	int args_ok = PyArg_ParseTuple(
+		args,
+		"OI",
+		&viewport,
+		&alignment
+	);
+
+	if (!args_ok) {
+		return 0;
+	}
+
+	if (alignment != 1 && alignment != 2 && alignment != 4 && alignment != 8) {
+		MGLError_Set("the alignment must be 1, 2, 4 or 8");
+		return 0;
+	}
+
+	if (self->samples) {
+		MGLError_Set("multisample textures cannot be read directly");
+		return 0;
+	}
+
+	int x = 0;
+	int y = 0;
+	int z = 0;
+	int width = self->width;
+	int height = self->height;
+	int depth = self->depth;
+
+	if (viewport != Py_None) {
+		if (Py_TYPE(viewport) != &PyTuple_Type) {
+			MGLError_Set("the viewport must be a tuple not %s", Py_TYPE(viewport)->tp_name);
+			return 0;
+		}
+
+		if (PyTuple_GET_SIZE(viewport) == 6) {
+
+			x = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 0));
+			y = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 1));
+			z = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 2));
+			width = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 3));
+			height = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 4));
+			depth = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 5));
+
+		} else if (PyTuple_GET_SIZE(viewport) == 3) {
+
+			width = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 0));
+			height = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 1));
+			depth = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 2));
+
+		} else {
+
+			MGLError_Set("the viewport size %d is invalid", PyTuple_GET_SIZE(viewport));
+			return 0;
+
+		}
+
+		if (PyErr_Occurred()) {
+			MGLError_Set("wrong values in the viewport");
+			return 0;
+		}
+
+	}
+
+	int expected_size = width * self->components * (self->floats ?  4 : 1);
+	expected_size = (expected_size + alignment - 1) / alignment * alignment;
+	expected_size = expected_size * height * depth;
+
+	PyObject * result = PyBytes_FromStringAndSize(0, expected_size);
+	char * data = PyBytes_AS_STRING(result);
+
+	const int formats[] = {0, GL_RED, GL_RG, GL_RGB, GL_RGBA};
+
+	int pixel_type = self->floats ? GL_FLOAT : GL_UNSIGNED_BYTE;
+	int format = formats[self->components];
+
+	const GLMethods & gl = self->context->gl;
+
+	gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
+	gl.BindTexture(GL_TEXTURE_3D, self->texture_obj);
+
+	gl.PixelStorei(GL_UNPACK_ALIGNMENT, alignment);
+	gl.GetTexImage(GL_TEXTURE_3D, 0, format, pixel_type, data);
+
+	return result;
+}
+
+PyObject * MGLTexture3D_read_into(MGLTexture3D * self, PyObject * args) {
+	PyObject * data;
+	PyObject * viewport;
+	int alignment;
+	int write_offset; // TODO: unused
+
+	int args_ok = PyArg_ParseTuple(
+		args,
+		"OOII",
+		&data,
+		&viewport,
+		&alignment,
+		&write_offset
+	);
+
+	if (!args_ok) {
+		return 0;
+	}
+
+	if (alignment != 1 && alignment != 2 && alignment != 4 && alignment != 8) {
+		MGLError_Set("the alignment must be 1, 2, 4 or 8");
+		return 0;
+	}
+
+	if (self->samples) {
+		MGLError_Set("multisample textures cannot be read directly");
+		return 0;
+	}
+
+	int x = 0;
+	int y = 0;
+	int z = 0;
+	int width = self->width;
+	int height = self->height;
+	int depth = self->depth;
+
+	if (viewport != Py_None) {
+		if (Py_TYPE(viewport) != &PyTuple_Type) {
+			MGLError_Set("the viewport must be a tuple not %s", Py_TYPE(viewport)->tp_name);
+			return 0;
+		}
+
+		if (PyTuple_GET_SIZE(viewport) == 6) {
+
+			x = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 0));
+			y = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 1));
+			z = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 2));
+			width = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 3));
+			height = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 4));
+			depth = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 5));
+
+		} else if (PyTuple_GET_SIZE(viewport) == 3) {
+
+			width = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 0));
+			height = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 1));
+			depth = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 1));
+
+		} else {
+
+			MGLError_Set("the viewport size %d is invalid", PyTuple_GET_SIZE(viewport));
+			return 0;
+
+		}
+
+		if (PyErr_Occurred()) {
+			MGLError_Set("wrong values in the viewport");
+			return 0;
+		}
+
+	}
+
+	int expected_size = width * self->components * (self->floats ?  4 : 1);
+	expected_size = (expected_size + alignment - 1) / alignment * alignment;
+	expected_size = expected_size * height * depth;
+
+	const int formats[] = {0, GL_RED, GL_RG, GL_RGB, GL_RGBA};
+
+	int pixel_type = self->floats ? GL_FLOAT : GL_UNSIGNED_BYTE;
+	int format = formats[self->components];
+
+	if (Py_TYPE(data) == &MGLBuffer_Type) {
+
+		MGLBuffer * buffer = (MGLBuffer *)data;
+
+		const GLMethods & gl = self->context->gl;
+
+		gl.BindBuffer(GL_PIXEL_PACK_BUFFER, buffer->buffer_obj);
+		gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
+		gl.BindTexture(GL_TEXTURE_3D, self->texture_obj);
+		gl.PixelStorei(GL_UNPACK_ALIGNMENT, alignment);
+		gl.GetTexImage(GL_TEXTURE_3D, 0, format, pixel_type, (void *)write_offset);
+		gl.BindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+
+	} else {
+
+		Py_buffer buffer_view;
+
+		int get_buffer = PyObject_GetBuffer(data, &buffer_view, PyBUF_WRITABLE);
+		if (get_buffer < 0) {
+			MGLError_Set("the buffer (%s) does not support buffer interface", Py_TYPE(data)->tp_name);
+			return 0;
+		}
+
+		if (buffer_view.len < write_offset + expected_size) {
+			MGLError_Set("the buffer is too small");
+			PyBuffer_Release(&buffer_view);
+			return 0;
+		}
+
+		char * ptr = (char *)buffer_view.buf + write_offset;
+
+		const GLMethods & gl = self->context->gl;
+		gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
+		gl.BindTexture(GL_TEXTURE_3D, self->texture_obj);
+		gl.PixelStorei(GL_UNPACK_ALIGNMENT, alignment);
+		gl.GetTexImage(GL_TEXTURE_3D, 0, format, pixel_type, ptr);
+
+		PyBuffer_Release(&buffer_view);
+
+	}
+
+	Py_RETURN_NONE;
+}
+
+PyObject * MGLTexture3D_write(MGLTexture3D * self, PyObject * args) {
+
+	// TODO: test this method
+
+	PyObject * data;
+	PyObject * viewport;
+	int alignment;
+
+	int args_ok = PyArg_ParseTuple(
+		args,
+		"OOI",
+		&data,
+		&viewport,
+		&alignment
+	);
+
+	if (!args_ok) {
+		return 0;
+	}
+
+	if (alignment != 1 && alignment != 2 && alignment != 4 && alignment != 8) {
+		MGLError_Set("the alignment must be 1, 2, 4 or 8");
+		return 0;
+	}
+
+	if (self->samples) {
+		MGLError_Set("multisample textures cannot be written directly");
+		return 0;
+	}
+
+	int x = 0;
+	int y = 0;
+	int z = 0;
+	int width = self->width;
+	int height = self->height;
+	int depth = self->depth;
+
+	Py_buffer buffer_view;
+
+	if (viewport != Py_None) {
+		if (Py_TYPE(viewport) != &PyTuple_Type) {
+			MGLError_Set("the viewport must be a tuple not %s", Py_TYPE(viewport)->tp_name);
+			return 0;
+		}
+
+		if (PyTuple_GET_SIZE(viewport) == 6) {
+
+			x = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 0));
+			y = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 1));
+			z = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 2));
+			width = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 3));
+			height = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 4));
+			depth = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 5));
+
+		} else if (PyTuple_GET_SIZE(viewport) == 3) {
+
+			width = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 0));
+			height = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 1));
+			depth = PyLong_AsLong(PyTuple_GET_ITEM(viewport, 2));
+
+		} else {
+
+			MGLError_Set("the viewport size %d is invalid", PyTuple_GET_SIZE(viewport));
+			return 0;
+
+		}
+
+		if (PyErr_Occurred()) {
+			MGLError_Set("wrong values in the viewport");
+			return 0;
+		}
+
+	}
+
+	int expected_size = width * self->components * (self->floats ?  4 : 1);
+	expected_size = (expected_size + alignment - 1) / alignment * alignment;
+	expected_size = expected_size * height * depth;
+
+	const int formats[] = {0, GL_RED, GL_RG, GL_RGB, GL_RGBA};
+
+	int pixel_type = self->floats ? GL_FLOAT : GL_UNSIGNED_BYTE;
+	int format = formats[self->components];
+
+	if (Py_TYPE(data) == &MGLBuffer_Type) {
+
+		MGLBuffer * buffer = (MGLBuffer *)data;
+
+		const GLMethods & gl = self->context->gl;
+
+		gl.BindBuffer(GL_PIXEL_UNPACK_BUFFER, buffer->buffer_obj);
+		gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
+		gl.BindTexture(GL_TEXTURE_3D, self->texture_obj);
+		gl.PixelStorei(GL_PACK_ALIGNMENT, alignment);
+		gl.TexSubImage3D(GL_TEXTURE_3D, 0, x, y, z, width, height, depth, format, pixel_type, 0);
+		gl.BindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+
+	} else {
+
+		PyObject_GetBuffer(data, &buffer_view, PyBUF_SIMPLE);
+
+		if (buffer_view.len != expected_size) {
+			MGLError_Set("data size mismatch %d != %d", buffer_view.len, expected_size);
+			if (data != Py_None) {
+				PyBuffer_Release(&buffer_view);
+			}
+			return 0;
+		}
+
+		const GLMethods & gl = self->context->gl;
+
+		gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
+		gl.BindTexture(GL_TEXTURE_3D, self->texture_obj);
+
+		gl.PixelStorei(GL_PACK_ALIGNMENT, alignment);
+		gl.TexSubImage3D(GL_TEXTURE_3D, 0, x, y, z, width, height, depth, format, pixel_type, buffer_view.buf);
+
+		PyBuffer_Release(&buffer_view);
+
+	}
+
+	Py_RETURN_NONE;
+}
+
+PyObject * MGLTexture3D_clear(MGLTexture3D * self, PyObject * args) {
+
+	// TODO:
+
+	PyErr_Format(PyExc_NotImplementedError, "NYI");
+	return 0;
+}
+
+PyObject * MGLTexture3D_use(MGLTexture3D * self, PyObject * args) {
+
+	// TODO: test this method
+
+	int index;
+
+	int args_ok = PyArg_ParseTuple(
+		args,
+		"I",
+		&index
+	);
+
+	if (!args_ok) {
+		return 0;
+	}
+
+	const GLMethods & gl = self->context->gl;
+	gl.ActiveTexture(GL_TEXTURE0 + index);
+	gl.BindTexture(GL_TEXTURE_3D, self->texture_obj);
+
+	Py_RETURN_NONE;
+}
+
+PyObject * MGLTexture3D_build_mipmaps(MGLTexture3D * self, PyObject * args) {
+
+	// TODO: test this method
+
+	int base = 0;
+	int max = 1000;
+
+	int args_ok = PyArg_ParseTuple(
+		args,
+		"II",
+		&base,
+		&max
+	);
+
+	if (!args_ok) {
+		return 0;
+	}
+
+
+	const GLMethods & gl = self->context->gl;
+
+	gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
+	gl.BindTexture(GL_TEXTURE_3D, self->texture_obj);
+
+	gl.TexParameteri(GL_TEXTURE_3D, GL_TEXTURE_BASE_LEVEL, base);
+	gl.TexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MAX_LEVEL, max);
+
+	gl.GenerateMipmap(GL_TEXTURE_3D);
+
+	gl.TexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+	gl.TexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+
+	// TODO: filter attrib
+
+	Py_RETURN_NONE;
+}
+
+PyObject * MGLTexture3D_release(MGLTexture3D * self) {
+	MGLTexture3D_Invalidate(self);
+	Py_RETURN_NONE;
+}
+
+PyMethodDef MGLTexture3D_tp_methods[] = {
+	{"read", (PyCFunction)MGLTexture3D_read, METH_VARARGS, 0},
+	{"read_into", (PyCFunction)MGLTexture3D_read_into, METH_VARARGS, 0},
+	{"write", (PyCFunction)MGLTexture3D_write, METH_VARARGS, 0},
+	{"clear", (PyCFunction)MGLTexture3D_clear, METH_VARARGS, 0},
+	{"use", (PyCFunction)MGLTexture3D_use, METH_VARARGS, 0},
+	{"build_mipmaps", (PyCFunction)MGLTexture3D_build_mipmaps, METH_VARARGS, 0},
+	{"release", (PyCFunction)MGLTexture3D_release, METH_NOARGS, 0},
+	{0},
+};
+
+PyObject * MGLTexture3D_get_repeat_x(MGLTexture3D * self) {
+	return PyBool_FromLong(self->repeat_x);
+}
+
+int MGLTexture3D_set_repeat_x(MGLTexture3D * self, PyObject * value) {
+
+	const GLMethods & gl = self->context->gl;
+
+	gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
+	gl.BindTexture(GL_TEXTURE_3D, self->texture_obj);
+
+	if (value == Py_True) {
+		gl.TexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+		self->repeat_x = true;
+		return 0;
+	} else if (value == Py_False) {
+		gl.TexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+		self->repeat_x = false;
+		return 0;
+	} else {
+		MGLError_Set("invalid value for texture_x");
+		return -1;
+	}
+}
+
+PyObject * MGLTexture3D_get_repeat_y(MGLTexture3D * self) {
+	return PyBool_FromLong(self->repeat_y);
+}
+
+int MGLTexture3D_set_repeat_y(MGLTexture3D * self, PyObject * value) {
+
+	const GLMethods & gl = self->context->gl;
+
+	gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
+	gl.BindTexture(GL_TEXTURE_3D, self->texture_obj);
+
+	if (value == Py_True) {
+		gl.TexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+		self->repeat_y = true;
+		return 0;
+	} else if (value == Py_False) {
+		gl.TexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+		self->repeat_y = false;
+		return 0;
+	} else {
+		MGLError_Set("invalid value for texture_y");
+		return -1;
+	}
+}
+
+PyObject * MGLTexture3D_get_repeat_z(MGLTexture3D * self) {
+	return PyBool_FromLong(self->repeat_z);
+}
+
+int MGLTexture3D_set_repeat_z(MGLTexture3D * self, PyObject * value) {
+
+	const GLMethods & gl = self->context->gl;
+
+	gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
+	gl.BindTexture(GL_TEXTURE_3D, self->texture_obj);
+
+	if (value == Py_True) {
+		gl.TexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_R, GL_REPEAT);
+		self->repeat_z = true;
+		return 0;
+	} else if (value == Py_False) {
+		gl.TexParameteri(GL_TEXTURE_3D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
+		self->repeat_z = false;
+		return 0;
+	} else {
+		MGLError_Set("invalid value for texture_z");
+		return -1;
+	}
+}
+
+PyObject * MGLTexture3D_get_filter(MGLTexture3D * self) {
+	Py_INCREF(self->filter->wrapper);
+	return self->filter->wrapper;
+}
+
+int MGLTexture3D_set_filter(MGLTexture3D * self, PyObject * value) {
+	if (Py_TYPE(value) != &MGLTextureFilter_Type) {
+		MGLError_Set("the value must be a TextureFilter not %s", Py_TYPE(value)->tp_name);
+		return -1;
+	}
+
+	MGLTextureFilter * filter = (MGLTextureFilter *)value;
+
+	Py_INCREF(filter);
+	Py_DECREF(self->filter);
+	self->filter = filter;
+
+	const GLMethods & gl = self->context->gl;
+
+	gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
+	gl.BindTexture(GL_TEXTURE_3D, self->texture_obj);
+	gl.TexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MIN_FILTER, filter->min_filter);
+	gl.TexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MAG_FILTER, filter->mag_filter);
+
+	return 0;
+}
+
+PyObject * MGLTexture3D_get_swizzle(MGLTexture3D * self, void * closure) {
+
+	if (self->depth) {
+		MGLError_Set("cannot get swizzle of depth textures");
+		return 0;
+	}
+
+
+	const GLMethods & gl = self->context->gl;
+
+	gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
+	gl.BindTexture(GL_TEXTURE_3D, self->texture_obj);
+
+	int swizzle_r = 0;
+	int swizzle_g = 0;
+	int swizzle_b = 0;
+	int swizzle_a = 0;
+
+	gl.GetTexParameteriv(GL_TEXTURE_3D, GL_TEXTURE_SWIZZLE_R, &swizzle_r);
+	gl.GetTexParameteriv(GL_TEXTURE_3D, GL_TEXTURE_SWIZZLE_G, &swizzle_g);
+	gl.GetTexParameteriv(GL_TEXTURE_3D, GL_TEXTURE_SWIZZLE_B, &swizzle_b);
+	gl.GetTexParameteriv(GL_TEXTURE_3D, GL_TEXTURE_SWIZZLE_A, &swizzle_a);
+
+	char swizzle[5] = {
+		char_from_swizzle(swizzle_r),
+		char_from_swizzle(swizzle_g),
+		char_from_swizzle(swizzle_b),
+		char_from_swizzle(swizzle_a),
+		0,
+	};
+
+	return PyUnicode_FromStringAndSize(swizzle, 4);
+}
+
+int MGLTexture3D_set_swizzle(MGLTexture3D * self, PyObject * value, void * closure) {
+	const char * swizzle = PyUnicode_AsUTF8(value);
+
+	if (self->depth) {
+		MGLError_Set("cannot set swizzle for depth textures");
+		return -1;
+	}
+
+	if (!swizzle[0]) {
+		MGLError_Set("the swizzle is empty");
+		return -1;
+	}
+
+	int tex_swizzle[4] = {-1, -1, -1, -1};
+
+	for (int i = 0; swizzle[i]; ++i) {
+		if (i > 3) {
+			MGLError_Set("the swizzle is too long");
+			return -1;
+		}
+
+		tex_swizzle[i] = swizzle_from_char(swizzle[i]);
+
+		if (tex_swizzle[i] == -1) {
+			MGLError_Set("'%c' is not a valid swizzle parameter", swizzle[i]);
+			return -1;
+		}
+	}
+
+
+	const GLMethods & gl = self->context->gl;
+
+	gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
+	gl.BindTexture(GL_TEXTURE_3D, self->texture_obj);
+
+	gl.TexParameteri(GL_TEXTURE_3D, GL_TEXTURE_SWIZZLE_R, tex_swizzle[0]);
+	if (tex_swizzle[1] != -1) {
+		gl.TexParameteri(GL_TEXTURE_3D, GL_TEXTURE_SWIZZLE_G, tex_swizzle[1]);
+		if (tex_swizzle[2] != -1) {
+			gl.TexParameteri(GL_TEXTURE_3D, GL_TEXTURE_SWIZZLE_B, tex_swizzle[2]);
+			if (tex_swizzle[3] != -1) {
+				gl.TexParameteri(GL_TEXTURE_3D, GL_TEXTURE_SWIZZLE_A, tex_swizzle[3]);
+			}
+		}
+	}
+
+	return 0;
+}
+
+PyObject * MGLTexture3D_get_width(MGLTexture3D * self, void * closure) {
+	return PyLong_FromLong(self->width);
+}
+
+PyObject * MGLTexture3D_get_height(MGLTexture3D * self, void * closure) {
+	return PyLong_FromLong(self->height);
+}
+
+PyObject * MGLTexture3D_get_components(MGLTexture3D * self, void * closure) {
+	return PyLong_FromLong(self->components);
+}
+
+PyObject * MGLTexture3D_get_samples(MGLTexture3D * self, void * closure) {
+	return PyLong_FromLong(self->samples);
+}
+
+PyObject * MGLTexture3D_get_depth(MGLTexture3D * self, void * closure) {
+	return PyBool_FromLong(self->depth);
+}
+
+MGLContext * MGLTexture3D_get_context(MGLTexture3D * self, void * closure) {
+	Py_INCREF(self->context);
+	return self->context;
+}
+
+PyObject * MGLTexture3D_get_glo(MGLTexture3D * self, void * closure) {
+	return PyLong_FromLong(self->texture_obj);
+}
+
+PyGetSetDef MGLTexture3D_tp_getseters[] = {
+	{(char *)"repeat_x", (getter)MGLTexture3D_get_repeat_x, (setter)MGLTexture3D_set_repeat_x, 0, 0},
+	{(char *)"repeat_y", (getter)MGLTexture3D_get_repeat_y, (setter)MGLTexture3D_set_repeat_y, 0, 0},
+	{(char *)"repeat_z", (getter)MGLTexture3D_get_repeat_z, (setter)MGLTexture3D_set_repeat_z, 0, 0},
+	{(char *)"filter", (getter)MGLTexture3D_get_filter, (setter)MGLTexture3D_set_filter, 0, 0},
+	{(char *)"swizzle", (getter)MGLTexture3D_get_swizzle, (setter)MGLTexture3D_set_swizzle, 0, 0},
+
+	{(char *)"width", (getter)MGLTexture3D_get_width, 0, 0, 0},
+	{(char *)"height", (getter)MGLTexture3D_get_height, 0, 0, 0},
+	{(char *)"depth", (getter)MGLTexture3D_get_depth, 0, 0, 0},
+	{(char *)"components", (getter)MGLTexture3D_get_components, 0, 0, 0},
+	{(char *)"context", (getter)MGLTexture3D_get_context, 0, 0, 0},
+	{(char *)"glo", (getter)MGLTexture3D_get_glo, 0, 0, 0},
+	{0},
+};
+
+PyTypeObject MGLTexture3D_Type = {
+	PyVarObject_HEAD_INIT(0, 0)
+	"mgl.Texture3D",                                        // tp_name
+	sizeof(MGLTexture3D),                                   // tp_basicsize
+	0,                                                      // tp_itemsize
+	(destructor)MGLTexture3D_tp_dealloc,                    // tp_dealloc
+	0,                                                      // tp_print
+	0,                                                      // tp_getattr
+	0,                                                      // tp_setattr
+	0,                                                      // tp_reserved
+	0,                                                      // tp_repr
+	0,                                                      // tp_as_number
+	0,                                                      // tp_as_sequence
+	0,                                                      // tp_as_mapping
+	0,                                                      // tp_hash
+	0,                                                      // tp_call
+	0,                                                      // tp_str
+	0,                                                      // tp_getattro
+	0,                                                      // tp_setattro
+	0,                                                      // tp_as_buffer
+	Py_TPFLAGS_DEFAULT,                                     // tp_flags
+	0,                                                      // tp_doc
+	0,                                                      // tp_traverse
+	0,                                                      // tp_clear
+	0,                                                      // tp_richcompare
+	0,                                                      // tp_weaklistoffset
+	0,                                                      // tp_iter
+	0,                                                      // tp_iternext
+	MGLTexture3D_tp_methods,                                // tp_methods
+	0,                                                      // tp_members
+	MGLTexture3D_tp_getseters,                              // tp_getset
+	0,                                                      // tp_base
+	0,                                                      // tp_dict
+	0,                                                      // tp_descr_get
+	0,                                                      // tp_descr_set
+	0,                                                      // tp_dictoffset
+	(initproc)MGLTexture3D_tp_init,                         // tp_init
+	0,                                                      // tp_alloc
+	MGLTexture3D_tp_new,                                    // tp_new
+};
+
+MGLTexture3D * MGLTexture3D_New() {
+	MGLTexture3D * self = (MGLTexture3D *)MGLTexture3D_tp_new(&MGLTexture3D_Type, 0, 0);
+	return self;
+}
+
+void MGLTexture3D_Invalidate(MGLTexture3D * texture) {
+	if (Py_TYPE(texture) == &MGLInvalidObject_Type) {
+
+		#ifdef MGL_VERBOSE
+		printf("MGLTexture3D_Invalidate %p already released\n", texture);
+		#endif
+
+		return;
+	}
+
+	#ifdef MGL_VERBOSE
+	printf("MGLTexture3D_Invalidate %p\n", texture);
+	#endif
+
+	texture->context->gl.DeleteTextures(1, (GLuint *)&texture->texture_obj);
+
+	Py_DECREF(texture->context);
+
+	Py_TYPE(texture) = &MGLInvalidObject_Type;
+
+	Py_DECREF(texture);
+}

--- a/src/Texture3D.cpp
+++ b/src/Texture3D.cpp
@@ -73,6 +73,7 @@ PyObject * MGLTexture3D_read(MGLTexture3D * self, PyObject * args) {
 	gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
 	gl.BindTexture(GL_TEXTURE_3D, self->texture_obj);
 
+	gl.PixelStorei(GL_PACK_ALIGNMENT, alignment);
 	gl.PixelStorei(GL_UNPACK_ALIGNMENT, alignment);
 	gl.GetTexImage(GL_TEXTURE_3D, 0, format, pixel_type, data);
 
@@ -124,6 +125,7 @@ PyObject * MGLTexture3D_read_into(MGLTexture3D * self, PyObject * args) {
 		gl.BindBuffer(GL_PIXEL_PACK_BUFFER, buffer->buffer_obj);
 		gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
 		gl.BindTexture(GL_TEXTURE_3D, self->texture_obj);
+		gl.PixelStorei(GL_PACK_ALIGNMENT, alignment);
 		gl.PixelStorei(GL_UNPACK_ALIGNMENT, alignment);
 		gl.GetTexImage(GL_TEXTURE_3D, 0, format, pixel_type, (void *)write_offset);
 		gl.BindBuffer(GL_PIXEL_PACK_BUFFER, 0);
@@ -149,6 +151,7 @@ PyObject * MGLTexture3D_read_into(MGLTexture3D * self, PyObject * args) {
 		const GLMethods & gl = self->context->gl;
 		gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
 		gl.BindTexture(GL_TEXTURE_3D, self->texture_obj);
+		gl.PixelStorei(GL_PACK_ALIGNMENT, alignment);
 		gl.PixelStorei(GL_UNPACK_ALIGNMENT, alignment);
 		gl.GetTexImage(GL_TEXTURE_3D, 0, format, pixel_type, ptr);
 
@@ -252,6 +255,7 @@ PyObject * MGLTexture3D_write(MGLTexture3D * self, PyObject * args) {
 		gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
 		gl.BindTexture(GL_TEXTURE_3D, self->texture_obj);
 		gl.PixelStorei(GL_PACK_ALIGNMENT, alignment);
+		gl.PixelStorei(GL_UNPACK_ALIGNMENT, alignment);
 		gl.TexSubImage3D(GL_TEXTURE_3D, 0, x, y, z, width, height, depth, format, pixel_type, 0);
 		gl.BindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
 
@@ -277,6 +281,7 @@ PyObject * MGLTexture3D_write(MGLTexture3D * self, PyObject * args) {
 		gl.BindTexture(GL_TEXTURE_3D, self->texture_obj);
 
 		gl.PixelStorei(GL_PACK_ALIGNMENT, alignment);
+		gl.PixelStorei(GL_UNPACK_ALIGNMENT, alignment);
 		gl.TexSubImage3D(GL_TEXTURE_3D, 0, x, y, z, width, height, depth, format, pixel_type, buffer_view.buf);
 
 		PyBuffer_Release(&buffer_view);

--- a/src/Texture3D.cpp
+++ b/src/Texture3D.cpp
@@ -470,12 +470,6 @@ int MGLTexture3D_set_filter(MGLTexture3D * self, PyObject * value) {
 
 PyObject * MGLTexture3D_get_swizzle(MGLTexture3D * self, void * closure) {
 
-	if (self->depth) {
-		MGLError_Set("cannot get swizzle of depth textures");
-		return 0;
-	}
-
-
 	const GLMethods & gl = self->context->gl;
 
 	gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
@@ -504,11 +498,6 @@ PyObject * MGLTexture3D_get_swizzle(MGLTexture3D * self, void * closure) {
 
 int MGLTexture3D_set_swizzle(MGLTexture3D * self, PyObject * value, void * closure) {
 	const char * swizzle = PyUnicode_AsUTF8(value);
-
-	if (self->depth) {
-		MGLError_Set("cannot set swizzle for depth textures");
-		return -1;
-	}
 
 	if (!swizzle[0]) {
 		MGLError_Set("the swizzle is empty");

--- a/src/Texture3D.hpp
+++ b/src/Texture3D.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "Python.hpp"
+
+#include "ContextMember.hpp"
+
+#include "TextureFilter.hpp"
+
+struct MGLTexture3D : public MGLContextMember {
+	int texture_obj;
+
+	int width;
+	int height;
+	int depth;
+
+	int components;
+
+	int samples;
+
+	bool floats;
+
+	MGLTextureFilter * filter;
+
+	bool repeat_x;
+	bool repeat_y;
+	bool repeat_z;
+};
+
+extern PyTypeObject MGLTexture3D_Type;
+
+MGLTexture3D * MGLTexture3D_New();
+void MGLTexture3D_Invalidate(MGLTexture3D * texture);

--- a/src/Uniform.cpp
+++ b/src/Uniform.cpp
@@ -481,6 +481,21 @@ void MGLUniform_Complete(MGLUniform * self, const GLMethods & gl) {
 			}
 			break;
 
+		case GL_SAMPLER_3D:
+			self->matrix = false;
+			self->dimension = 1;
+			self->element_size = 4;
+			self->gl_value_reader_proc = (MGLProc)gl.GetUniformiv;
+			self->gl_value_writer_proc = (MGLProc)gl.ProgramUniform1iv;
+			if (self->array_length > 1) {
+				self->value_getter = (MGLProc)MGLUniform_sampler_array_value_getter;
+				self->value_setter = (MGLProc)MGLUniform_sampler_array_value_setter;
+			} else {
+				self->value_getter = (MGLProc)MGLUniform_sampler_value_getter;
+				self->value_setter = (MGLProc)MGLUniform_sampler_value_setter;
+			}
+			break;
+
 		case GL_SAMPLER_2D_SHADOW:
 			self->matrix = false;
 			self->dimension = 1;

--- a/tests/basic/test_simple_texture_3d.py
+++ b/tests/basic/test_simple_texture_3d.py
@@ -17,55 +17,55 @@ class TestCase(unittest.TestCase):
         self.assertEqual(self.ctx.error, 'GL_NO_ERROR')
 
     def test_texture_3d_create_1(self):
-        self.ctx.texture3D((8, 8, 8), 3)
+        self.ctx.texture3d((8, 8, 8), 3)
 
     def test_texture_3d_create_2(self):
         pixels = b'\x10\x20\x30' * 8 * 8 * 8
-        self.ctx.texture3D((8, 8, 8), 3, pixels)
+        self.ctx.texture3d((8, 8, 8), 3, pixels)
 
     def test_texture_3d_create_string(self):
         pixels = 'abc' * 8 * 8
         with self.assertRaises(Exception):
-            self.ctx.texture3D((8, 8, 8), 3, pixels)
+            self.ctx.texture3d((8, 8, 8), 3, pixels)
 
     def test_texture_3d_create_wrong_size(self):
         with self.assertRaises(Exception):
-            self.ctx.texture3D((8, 8), 3)
+            self.ctx.texture3d((8, 8), 3)
 
     def test_texture_3d_get_swizzle(self):
-        tex = self.ctx.texture3D((8, 8, 8), 4)
+        tex = self.ctx.texture3d((8, 8, 8), 4)
         self.assertEqual(tex.swizzle, 'RGBA')
 
     def test_texture_3d_swizzle_1(self):
-        tex = self.ctx.texture3D((8, 8, 8), 4)
+        tex = self.ctx.texture3d((8, 8, 8), 4)
         tex.swizzle = 'argb'
         self.assertEqual(tex.swizzle, 'ARGB')
 
     def test_texture_3d_swizzle_2(self):
-        tex = self.ctx.texture3D((8, 8, 8), 1)
+        tex = self.ctx.texture3d((8, 8, 8), 1)
         tex.swizzle = 'RRRR'
         self.assertEqual(tex.swizzle, 'RRRR')
 
     def test_texture_3d_swizzle_3(self):
-        tex = self.ctx.texture3D((8, 8, 8), 2)
+        tex = self.ctx.texture3d((8, 8, 8), 2)
         tex.swizzle = '01RG'
         self.assertEqual(tex.swizzle, '01RG')
 
     def test_texture_3d_read(self):
         pixels = b'\x10\x20\x30' * 8 * 8 * 8
-        tex = self.ctx.texture3D((8, 8, 8), 3, pixels)
+        tex = self.ctx.texture3d((8, 8, 8), 3, pixels)
         self.assertEqual(tex.read(), pixels)
 
     def test_texture_3d_read_into(self):
         pixels = b'\x10\x20\x30' * 8 * 8 * 8
-        tex = self.ctx.texture3D((8, 8, 8), 3, pixels)
+        tex = self.ctx.texture3d((8, 8, 8), 3, pixels)
         buf = bytearray(8 * 8 * 8 * 3)
         tex.read_into(buf)
         self.assertEqual(bytes(buf), pixels)
 
     def test_texture_3d_read_into_pbo(self):
         pixels = b'\x10\x20\x30' * 8 * 8 * 8
-        tex = self.ctx.texture3D((8, 8, 8), 3, pixels)
+        tex = self.ctx.texture3d((8, 8, 8), 3, pixels)
         buf = self.ctx.buffer(reserve=8 * 8 * 8 * 3)
 
         tex.read_into(buf)
@@ -75,7 +75,7 @@ class TestCase(unittest.TestCase):
         pixels1 = b'\x00\x00\x00' * 8 * 8 * 8
         pixels2 = b'\xff\xff\xff' * 8 * 8 * 8
 
-        tex = self.ctx.texture3D((8, 8, 8), 3, pixels1)
+        tex = self.ctx.texture3d((8, 8, 8), 3, pixels1)
         self.assertEqual(tex.read(), pixels1)
 
         tex.write(pixels2)
@@ -86,7 +86,7 @@ class TestCase(unittest.TestCase):
         pixels2 = b'\xff\xff\xff' * 6 * 6 * 6
         pixels3 = b'\x10\x20\x30'
 
-        tex = self.ctx.texture3D((8, 8, 8), 3)
+        tex = self.ctx.texture3d((8, 8, 8), 3)
 
         tex.write(pixels1, viewport=(0, 0, 0, 8, 8, 8))
         tex.write(pixels2, viewport=(1, 1, 1, 6, 6, 6))

--- a/tests/basic/test_simple_texture_3d.py
+++ b/tests/basic/test_simple_texture_3d.py
@@ -1,0 +1,109 @@
+import unittest
+
+import ModernGL
+
+
+class TestCase(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ctx = ModernGL.create_standalone_context()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.ctx.release()
+
+    def tearDown(self):
+        self.assertEqual(self.ctx.error, 'GL_NO_ERROR')
+
+    def test_texture_3d_create_1(self):
+        self.ctx.texture3D((8, 8, 8), 3)
+
+    def test_texture_3d_create_2(self):
+        pixels = b'\x10\x20\x30' * 8 * 8 * 8
+        self.ctx.texture3D((8, 8, 8), 3, pixels)
+
+    def test_texture_3d_create_string(self):
+        pixels = 'abc' * 8 * 8
+        with self.assertRaises(Exception):
+            self.ctx.texture3D((8, 8, 8), 3, pixels)
+
+    def test_texture_3d_create_wrong_size(self):
+        with self.assertRaises(Exception):
+            self.ctx.texture3D((8, 8), 3)
+
+    def test_texture_3d_get_swizzle(self):
+        tex = self.ctx.texture3D((8, 8, 8), 4)
+        self.assertEqual(tex.swizzle, 'RGBA')
+
+    def test_texture_3d_swizzle_1(self):
+        tex = self.ctx.texture3D((8, 8, 8), 4)
+        tex.swizzle = 'argb'
+        self.assertEqual(tex.swizzle, 'ARGB')
+
+    def test_texture_3d_swizzle_2(self):
+        tex = self.ctx.texture3D((8, 8, 8), 1)
+        tex.swizzle = 'RRRR'
+        self.assertEqual(tex.swizzle, 'RRRR')
+
+    def test_texture_3d_swizzle_3(self):
+        tex = self.ctx.texture3D((8, 8, 8), 2)
+        tex.swizzle = '01RG'
+        self.assertEqual(tex.swizzle, '01RG')
+
+    def test_texture_3d_read(self):
+        pixels = b'\x10\x20\x30' * 8 * 8 * 8
+        tex = self.ctx.texture3D((8, 8, 8), 3, pixels)
+        self.assertEqual(tex.read(), pixels)
+
+    def test_texture_3d_read_into(self):
+        pixels = b'\x10\x20\x30' * 8 * 8 * 8
+        tex = self.ctx.texture3D((8, 8, 8), 3, pixels)
+        buf = bytearray(8 * 8 * 8 * 3)
+        tex.read_into(buf)
+        self.assertEqual(bytes(buf), pixels)
+
+    def test_texture_3d_read_into_pbo(self):
+        pixels = b'\x10\x20\x30' * 8 * 8 * 8
+        tex = self.ctx.texture3D((8, 8, 8), 3, pixels)
+        buf = self.ctx.buffer(reserve=8 * 8 * 8 * 3)
+
+        tex.read_into(buf)
+        self.assertEqual(buf.read(), pixels)
+
+    def test_texture_3d_write_1(self):
+        pixels1 = b'\x00\x00\x00' * 8 * 8 * 8
+        pixels2 = b'\xff\xff\xff' * 8 * 8 * 8
+
+        tex = self.ctx.texture3D((8, 8, 8), 3, pixels1)
+        self.assertEqual(tex.read(), pixels1)
+
+        tex.write(pixels2)
+        self.assertEqual(tex.read(), pixels2)
+
+    def test_texture_3d_write_2(self):
+        pixels1 = b'\x00\x00\x00' * 8 * 8 * 8
+        pixels2 = b'\xff\xff\xff' * 6 * 6 * 6
+        pixels3 = b'\x10\x20\x30'
+
+        tex = self.ctx.texture3D((8, 8, 8), 3)
+
+        tex.write(pixels1, viewport=(0, 0, 0, 8, 8, 8))
+        tex.write(pixels2, viewport=(1, 1, 1, 6, 6, 6))
+        tex.write(pixels3, viewport=(2, 4, 6, 1, 1, 1))
+
+        def pixel(x, y, z):
+            if x == 2 and y == 4 and z == 6:
+                return b'\x10\x20\x30'
+
+            if x == 0 or y == 0 or z == 0 or x == 7 or y == 7 or z == 7:
+                return b'\x00\x00\x00'
+
+            return b'\xff\xff\xff'
+
+        expectation = b''.join(pixel(x, y, z) for z in range(8) for y in range(8) for x in range(8))
+        self.assertEqual(tex.read(), expectation)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_sampler_uniforms.py
+++ b/tests/test_sampler_uniforms.py
@@ -1,0 +1,55 @@
+import unittest
+
+import ModernGL
+
+
+class TestCase(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ctx = ModernGL.create_standalone_context()
+
+    def tearDown(self):
+        self.assertEqual(self.ctx.error, 'GL_NO_ERROR')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.ctx.release()
+
+    def test_sampler_2D_getsetter(self):
+        self.prog = self.ctx.program(self.ctx.vertex_shader('''
+            #version 330
+            uniform sampler2D Texture2D;
+            void main() {
+                gl_Position = texture(Texture2D, vec2(0.0, 0.0));
+            }
+        '''))
+
+        sampler_uniform = self.prog.uniforms['Texture2D']
+
+        sampler_uniform.value = 3
+        self.assertEqual(sampler_uniform.value, 3)
+
+        sampler_uniform.value = 1
+        self.assertEqual(sampler_uniform.value, 1)
+
+    def test_sampler_3D_getsetter(self):
+        self.prog = self.ctx.program(self.ctx.vertex_shader('''
+            #version 330
+            uniform sampler3D Texture3D;
+            void main() {
+                gl_Position = texture(Texture3D, vec3(0.0, 0.0, 0.0));
+            }
+        '''))
+
+        sampler_uniform = self.prog.uniforms['Texture3D']
+
+        sampler_uniform.value = 3
+        self.assertEqual(sampler_uniform.value, 3)
+
+        sampler_uniform.value = 1
+        self.assertEqual(sampler_uniform.value, 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Description

Partial support for 3D textures

### List of changes

- **added** `Texture3D` class and `Context.texture3d(...)` method
- **added** 3D uniform getter and setter for the `sampler3D` glsl type
- **added** `read` and `write` methods for `Texture3D` _(and PBO)_
- **added** `width`, `height` and `depth` attributes for `Texture3D`
- **added** examples and tests for 3D textures

### List of TODOs

- multisample texture3d creation
- framebuffer attachable layers (design decision needed)
- blit the layers to 2D textures
