### PR TITLE
fallback display

### DIFF
--- a/src/GLContext.cpp
+++ b/src/GLContext.cpp
@@ -590,6 +590,10 @@ GLContext CreateGLContext(int width, int height) {
 	Display * dpy = XOpenDisplay(0);
 
 	if (!dpy) {
+		dpy = XOpenDisplay(":0.0");
+	}
+
+	if (!dpy) {
 		MGLError_Set("cannot detect the display");
 		return context;
 	}


### PR DESCRIPTION
### Description

When `XOpenDisplay(0)` returns `NULL` `XOpenDisplay(":0.0")` will be called.

The source of the problem: [Headless-rendering-with-python issue](https://github.com/cprogrammer1994/Headless-rendering-with-python/issues/2)

### List of changes

- **added** fallback display on linux (when `DISPLAY` is not in the env)

### Style for python files:

- Please use 4 spaces (not tabs).
- Please follow the pep8 style guide.
