### PR TITLE
Implement front_face

### DIFF
--- a/ModernGL/context.py
+++ b/ModernGL/context.py
@@ -160,7 +160,7 @@ class Context:
     @property
     def wireframe(self) -> bool:
         '''
-            bool: The default framebuffer.
+            bool: Wireframe settings for debugging.
         '''
 
         return self.mglo.wireframe
@@ -168,6 +168,18 @@ class Context:
     @wireframe.setter
     def wireframe(self, value):
         self.mglo.wireframe = value
+
+    @property
+    def front_face(self) -> str:
+        '''
+            str: The front_face.
+        '''
+
+        return self.mglo.front_face
+
+    @front_face.setter
+    def front_face(self, value):
+        self.mglo.front_face = str(value)
 
     @property
     def error(self) -> str:

--- a/examples/GLWindow/front_face_and_back_face.py
+++ b/examples/GLWindow/front_face_and_back_face.py
@@ -1,0 +1,52 @@
+import struct
+
+import GLWindow
+import ModernGL
+
+wnd = GLWindow.create_window()
+ctx = ModernGL.create_context()
+
+prog = ctx.program([
+    ctx.vertex_shader('''
+        #version 330
+
+        in vec2 vert;
+
+        void main() {
+            gl_Position = vec4(vert, 0.0, 1.0);
+        }
+    '''),
+    ctx.fragment_shader('''
+        #version 330
+
+        out vec4 color;
+
+        void main() {
+            color = vec4(0.3, 0.5, 1.0, 1.0);
+        }
+    '''),
+])
+
+vbo = ctx.buffer(struct.pack(
+    '12f',
+    -0.5, -0.5,
+    -0.5, 0.5,
+    0.5, -0.5,
+    -0.5, 0.5,
+    0.5, -0.5,
+    0.5, 0.5,
+))
+
+vao = ctx.simple_vertex_array(prog, vbo, ['vert'])
+
+ctx.enable(ModernGL.CULL_FACE)
+
+while wnd.update():
+    if wnd.time % 1.0 < 0.5:
+        ctx.front_face = 'CW'
+    else:
+        ctx.front_face = 'CCW'
+
+    ctx.viewport = wnd.viewport
+    ctx.clear(0.9, 0.9, 0.9)
+    vao.render()

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -1696,9 +1696,32 @@ int MGLContext_set_wireframe(MGLContext * self, PyObject * value) {
 		self->gl.PolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 		self->wireframe = false;
 	} else {
-		MGLError_Set("invalid value for enabled");
+		MGLError_Set("invalid value for wireframe");
 		return -1;
 	}
+	return 0;
+}
+
+PyObject * MGLContext_get_front_face(MGLContext * self) {
+	if (self->front_face == GL_CW) {
+		return PyUnicode_FromString("CW");
+	}
+	return PyUnicode_FromString("CCW");
+}
+
+int MGLContext_set_front_face(MGLContext * self, PyObject * value) {
+	const char * str = PyUnicode_AsUTF8(value);
+
+	if (!strcmp(str, "CW")) {
+		self->front_face = GL_CW;
+	} else if (!strcmp(str, "CCW")) {
+		self->front_face = GL_CCW;
+	} else {
+		MGLError_Set("invalid value for front_face");
+		return -1;
+	}
+
+	self->gl.FrontFace(self->front_face);
 	return 0;
 }
 
@@ -2283,6 +2306,7 @@ PyGetSetDef MGLContext_tp_getseters[] = {
 	{(char *)"default_framebuffer", (getter)MGLContext_get_default_framebuffer, 0, 0, 0},
 
 	{(char *)"wireframe", (getter)MGLContext_get_wireframe, (setter)MGLContext_set_wireframe, 0, 0},
+	{(char *)"front_face", (getter)MGLContext_get_front_face, (setter)MGLContext_set_front_face, 0, 0},
 
 	{(char *)"error", (getter)MGLContext_get_error, 0, 0, 0},
 	{(char *)"vendor", (getter)MGLContext_get_vendor, 0, 0, 0},
@@ -2435,4 +2459,7 @@ void MGLContext_Initialize(MGLContext * self) {
 
 	Py_INCREF(self->default_framebuffer);
 	self->bound_framebuffer = self->default_framebuffer;
+
+	self->wireframe = false;
+	self->front_face = GL_CCW;
 }

--- a/src/Context.hpp
+++ b/src/Context.hpp
@@ -21,6 +21,7 @@ struct MGLContext : public MGLObject {
 	int max_texture_units;
 	int default_texture_unit;
 
+	int front_face;
 	bool wireframe;
 
 	GLMethods gl;


### PR DESCRIPTION
### Description

Implementation for changing the winding order:

```python
ctx.front_face = 'CW'
ctx.front_face = 'CCW'
```

### List of changes

- **added** Context `front_face` attribute
- **added** an example using `front_face`

### Style for python files:

- Please use 4 spaces (not tabs).
- Please follow the pep8 style guide.
