### PR TITLE
Added get method to Map-like objects

### DIFF
--- a/ModernGL/members.py
+++ b/ModernGL/members.py
@@ -234,6 +234,9 @@ class UniformMap:
     def __ne__(self, other):
         return self.mglo is not other.mglo
 
+    def get(self, key, default = None):
+        return self.mglo.get(key, default)
+
 
 class UniformBlock:
     '''
@@ -344,6 +347,9 @@ class UniformBlockMap:
     def __ne__(self, other):
         return self.mglo is not other.mglo
 
+    def get(self, key, default = None):
+        return self.mglo.get(key, default)
+
 
 class Varying:
     '''
@@ -433,6 +439,9 @@ class VaryingMap:
 
     def __ne__(self, other):
         return self.mglo is not other.mglo
+
+    def get(self, key, default = None):
+        return self.mglo.get(key, default)
 
 
 class Attribute:
@@ -654,6 +663,9 @@ class AttributeMap:
     def __ne__(self, other):
         return self.mglo is not other.mglo
 
+    def get(self, key, default = None):
+        return self.mglo.get(key, default)
+
 
 class Subroutine:
     '''
@@ -747,6 +759,9 @@ class SubroutineMap:
     def __ne__(self, other):
         return self.mglo is not other.mglo
 
+    def get(self, key, default = None):
+        return self.mglo.get(key, default)
+
 
 class SubroutineUniform:
     '''
@@ -836,6 +851,9 @@ class SubroutineUniformMap:
 
     def __ne__(self, other):
         return self.mglo is not other.mglo
+
+    def get(self, key, default = None):
+        return self.mglo.get(key, default)
 
 
 class ProgramStage:

--- a/ModernGL/vertex_arrays.py
+++ b/ModernGL/vertex_arrays.py
@@ -125,6 +125,9 @@ class VertexArrayAttributeMap:
     def __ne__(self, other):
         return self.mglo is not other.mglo
 
+    def get(self, key, default = None):
+        return self.mglo.get(key, default)
+
     @staticmethod
     def new(obj):
         '''


### PR DESCRIPTION
### Description

Map-like objects didn' have any `get` method for the underlying `dict` member.

### List of changes

- **added** Each Map has now a `get` method with the default value of `None`.
