### PR TITLE
VertexArray index element size can be INT, SHORT and BYTE

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Code is tested with [pep8], [flake8], [prospector] and [pylint]
 - [stuaxo](https://github.com/stuaxo)
 - [Tomi Aarnio](https://github.com/toaarnio)
 - [Joshua Reibert](https://github.com/joshua-r)
+- [Einar Forselv](https://github.com/einarf)
 
 and [many others](https://github.com/cprogrammer1994/ModernGL/graphs/contributors)
 

--- a/docs/reference/context.rst
+++ b/docs/reference/context.rst
@@ -16,8 +16,8 @@ ModernGL Objects
 ----------------
 
 .. automethod:: Context.program(vertex_shader, fragment_shader=None, geometry_shader=None, tess_control_shader=None, tess_evaluation_shader=None, varyings=()) -> Program
-.. automethod:: Context.simple_vertex_array(program, buffer, *attributes, index_buffer=None) -> VertexArray
-.. automethod:: Context.vertex_array(program, content, index_buffer=None, skip_errors=False) -> VertexArray
+.. automethod:: Context.simple_vertex_array(program, buffer, *attributes, index_buffer=None, index_element_size=4) -> VertexArray
+.. automethod:: Context.vertex_array(program, content, index_buffer=None, index_element_size=4, skip_errors=False) -> VertexArray
 .. automethod:: Context.buffer(data=None, reserve=0, dynamic=False) -> Buffer
 .. automethod:: Context.texture(size, components, data=None, samples=0, alignment=1, dtype='f1') -> Texture
 .. automethod:: Context.depth_texture(size, data=None, samples=0, alignment=4) -> Texture

--- a/docs/reference/vertex_array.rst
+++ b/docs/reference/vertex_array.rst
@@ -15,10 +15,10 @@ VertexArray
 Create
 ------
 
-.. automethod:: Context.simple_vertex_array(program, buffer, *attributes, index_buffer=None) -> VertexArray
+.. automethod:: Context.simple_vertex_array(program, buffer, *attributes, index_buffer=None, index_element_size=4) -> VertexArray
     :noindex:
 
-.. automethod:: Context.vertex_array(program, content, index_buffer=None, skip_errors=False) -> VertexArray
+.. automethod:: Context.vertex_array(program, content, index_buffer=None, index_element_size=4, skip_errors=False) -> VertexArray
     :noindex:
 
 Methods

--- a/docs/reference/vertex_array.rst
+++ b/docs/reference/vertex_array.rst
@@ -34,6 +34,7 @@ Attributes
 
 .. autoattribute:: VertexArray.program
 .. autoattribute:: VertexArray.index_buffer
+.. autoattribute:: VertexArray.index_element_size
 .. autoattribute:: VertexArray.vertices
 .. autoattribute:: VertexArray.subroutines
 .. autoattribute:: VertexArray.glo

--- a/src/Types.hpp
+++ b/src/Types.hpp
@@ -361,6 +361,8 @@ struct MGLVertexArray {
 
 	MGLProgram * program;
 	MGLBuffer * index_buffer;
+    int index_element_size;
+    int index_element_type;
 
 	unsigned * subroutines;
 	int num_subroutines;

--- a/src/Types.hpp
+++ b/src/Types.hpp
@@ -361,8 +361,8 @@ struct MGLVertexArray {
 
 	MGLProgram * program;
 	MGLBuffer * index_buffer;
-  int index_element_size;
-  int index_element_type;
+	int index_element_size;
+	int index_element_type;
 
 	unsigned * subroutines;
 	int num_subroutines;

--- a/src/Types.hpp
+++ b/src/Types.hpp
@@ -361,8 +361,8 @@ struct MGLVertexArray {
 
 	MGLProgram * program;
 	MGLBuffer * index_buffer;
-    int index_element_size;
-    int index_element_type;
+  int index_element_size;
+  int index_element_type;
 
 	unsigned * subroutines;
 	int num_subroutines;

--- a/src/VertexArray.cpp
+++ b/src/VertexArray.cpp
@@ -114,10 +114,10 @@ PyObject * MGLContext_vertex_array(MGLContext * self, PyObject * args) {
 		return 0;
 	}
 
-    if (index_element_size != 1 && index_element_size != 2 && index_element_size != 4) {
-        MGLError_Set("index_element_size must be 1, 2, or 4, not %d", index_element_size);
-        return 0;
-    }
+  if (index_element_size != 1 && index_element_size != 2 && index_element_size != 4) {
+    MGLError_Set("index_element_size must be 1, 2, or 4, not %d", index_element_size);
+    return 0;
+  }
 
 	const GLMethods & gl = self->gl;
 
@@ -141,12 +141,12 @@ PyObject * MGLContext_vertex_array(MGLContext * self, PyObject * args) {
 	array->index_buffer = index_buffer;
 	array->index_element_size = index_element_size;
 
-    if (index_element_size == 4)
-        array->index_element_type = GL_UNSIGNED_INT;
-    else if (index_element_size == 2)
-        array->index_element_type = GL_UNSIGNED_SHORT;
-    else if (index_element_size == 1)
-        array->index_element_type = GL_UNSIGNED_BYTE;
+  if (index_element_size == 4)
+    array->index_element_type = GL_UNSIGNED_INT;
+  else if (index_element_size == 2)
+    array->index_element_type = GL_UNSIGNED_SHORT;
+  else if (index_element_size == 1)
+    array->index_element_type = GL_UNSIGNED_BYTE;
 
 	if (index_buffer != (MGLBuffer *)Py_None) {
 		array->num_vertices = (int)(index_buffer->size / index_element_size);

--- a/src/VertexArray.cpp
+++ b/src/VertexArray.cpp
@@ -6,7 +6,7 @@ PyObject * MGLContext_vertex_array(MGLContext * self, PyObject * args) {
 	MGLProgram * program;
 	PyObject * content;
 	MGLBuffer * index_buffer;
-    int index_element_size;
+	int index_element_size;
 	int skip_errors;
 
 	int args_ok = PyArg_ParseTuple(

--- a/src/VertexArray.cpp
+++ b/src/VertexArray.cpp
@@ -141,12 +141,8 @@ PyObject * MGLContext_vertex_array(MGLContext * self, PyObject * args) {
 	array->index_buffer = index_buffer;
 	array->index_element_size = index_element_size;
 
-	if (index_element_size == 4)
-		array->index_element_type = GL_UNSIGNED_INT;
-	else if (index_element_size == 2)
-		array->index_element_type = GL_UNSIGNED_SHORT;
-	else if (index_element_size == 1)
-		array->index_element_type = GL_UNSIGNED_BYTE;
+    const int element_types[5] = {0, GL_UNSIGNED_BYTE, GL_UNSIGNED_SHORT, 0, GL_UNSIGNED_INT};
+	array->index_element_type = element_types[index_element_size];
 
 	if (index_buffer != (MGLBuffer *)Py_None) {
 		array->num_vertices = (int)(index_buffer->size / index_element_size);

--- a/src/VertexArray.cpp
+++ b/src/VertexArray.cpp
@@ -141,7 +141,7 @@ PyObject * MGLContext_vertex_array(MGLContext * self, PyObject * args) {
 	array->index_buffer = index_buffer;
 	array->index_element_size = index_element_size;
 
-    const int element_types[5] = {0, GL_UNSIGNED_BYTE, GL_UNSIGNED_SHORT, 0, GL_UNSIGNED_INT};
+	const int element_types[5] = {0, GL_UNSIGNED_BYTE, GL_UNSIGNED_SHORT, 0, GL_UNSIGNED_INT};
 	array->index_element_type = element_types[index_element_size];
 
 	if (index_buffer != (MGLBuffer *)Py_None) {

--- a/src/VertexArray.cpp
+++ b/src/VertexArray.cpp
@@ -141,12 +141,12 @@ PyObject * MGLContext_vertex_array(MGLContext * self, PyObject * args) {
 	array->index_buffer = index_buffer;
 	array->index_element_size = index_element_size;
 
-  if (index_element_size == 4)
-    array->index_element_type = GL_UNSIGNED_INT;
-  else if (index_element_size == 2)
-    array->index_element_type = GL_UNSIGNED_SHORT;
-  else if (index_element_size == 1)
-    array->index_element_type = GL_UNSIGNED_BYTE;
+	if (index_element_size == 4)
+		array->index_element_type = GL_UNSIGNED_INT;
+	else if (index_element_size == 2)
+		array->index_element_type = GL_UNSIGNED_SHORT;
+	else if (index_element_size == 1)
+		array->index_element_type = GL_UNSIGNED_BYTE;
 
 	if (index_buffer != (MGLBuffer *)Py_None) {
 		array->num_vertices = (int)(index_buffer->size / index_element_size);

--- a/src/VertexArray.cpp
+++ b/src/VertexArray.cpp
@@ -114,10 +114,10 @@ PyObject * MGLContext_vertex_array(MGLContext * self, PyObject * args) {
 		return 0;
 	}
 
-  if (index_element_size != 1 && index_element_size != 2 && index_element_size != 4) {
-    MGLError_Set("index_element_size must be 1, 2, or 4, not %d", index_element_size);
-    return 0;
-  }
+	if (index_element_size != 1 && index_element_size != 2 && index_element_size != 4) {
+		MGLError_Set("index_element_size must be 1, 2, or 4, not %d", index_element_size);
+		return 0;
+	}
 
 	const GLMethods & gl = self->gl;
 

--- a/tests/test_vertex_array_index.py
+++ b/tests/test_vertex_array_index.py
@@ -31,8 +31,8 @@ class TestCase(unittest.TestCase):
             4.0, 2.0, 7.5, 1.8,
             3.0, 2.8, 6.0, 10.0
         ]
-        indices = [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
         count = 10
+        indices = [0, 1] * 10
 
         # UNSIGNED_INT index
         vbo1 = self.ctx.buffer(np.array(vertices, dtype='f4').tobytes())
@@ -80,7 +80,7 @@ class TestCase(unittest.TestCase):
             4.0, 2.0, 7.5, 1.8,
             3.0, 2.8, 6.0, 10.0
         ]
-        indices = [0, 1, 0, 1, 0, 1, 0, 1.0, 1.0]
+        indices = [0, 1, 0, 1, 0, 1, 0, 1, 0]
 
         vbo1 = self.ctx.buffer(np.array(vertices, dtype='f4').tobytes())
         index_u4 = self.ctx.buffer(np.array(indices, dtype='u4').tobytes())

--- a/tests/test_vertex_array_index.py
+++ b/tests/test_vertex_array_index.py
@@ -61,6 +61,33 @@ class TestCase(unittest.TestCase):
         res = np.frombuffer(vbo2.read(), dtype='f4')
         np.testing.assert_almost_equal(res, vertices * count)
 
+    def test_2(self):
+        prog = self.ctx.program(
+            vertex_shader='''
+                #version 330
+
+                in vec4 in_vert;
+                out vec4 out_vert;
+
+                void main() {
+                    out_vert = in_vert;
+                }
+            ''',
+            varyings=['out_vert']
+        )
+
+        vertices = [
+            4.0, 2.0, 7.5, 1.8,
+            3.0, 2.8, 6.0, 10.0
+        ]
+        indices = [0, 1, 0, 1, 0, 1, 0, 1.0, 1.0]
+
+        vbo1 = self.ctx.buffer(np.array(vertices, dtype='f4').tobytes())
+        index_u4 = self.ctx.buffer(np.array(indices, dtype='u4').tobytes())
+
+        with self.assertRaises(moderngl.Error):
+            self.ctx.simple_vertex_array(prog, vbo1, 'in_vert', index_buffer=index_u4, index_element_size=0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_vertex_array_index.py
+++ b/tests/test_vertex_array_index.py
@@ -1,0 +1,66 @@
+import unittest
+
+import moderngl
+import numpy as np
+
+from common import get_context
+
+
+class TestCase(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ctx = get_context()
+
+    def test_1(self):
+        prog = self.ctx.program(
+            vertex_shader='''
+                #version 330
+
+                in vec4 in_vert;
+                out vec4 out_vert;
+
+                void main() {
+                    out_vert = in_vert;
+                }
+            ''',
+            varyings=['out_vert']
+        )
+
+        vertices = [
+            4.0, 2.0, 7.5, 1.8,
+            3.0, 2.8, 6.0, 10.0
+        ]
+        indices = [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
+        count = 10
+
+        # UNSIGNED_INT index
+        vbo1 = self.ctx.buffer(np.array(vertices, dtype='f4').tobytes())
+        vbo2 = self.ctx.buffer(reserve=vbo1.size * count)
+        index = self.ctx.buffer(np.array(indices, dtype='u4').tobytes())
+        vao = self.ctx.simple_vertex_array(prog, vbo1, 'in_vert', index_buffer=index, index_element_size=4)
+        vao.transform(vbo2, moderngl.POINTS)
+        res = np.frombuffer(vbo2.read(), dtype='f4')
+        np.testing.assert_almost_equal(res, vertices * count)
+
+        # UNSIGNED_SHORT index
+        vbo1 = self.ctx.buffer(np.array(vertices, dtype='f4').tobytes())
+        vbo2 = self.ctx.buffer(reserve=vbo1.size * count)
+        index = self.ctx.buffer(np.array(indices, dtype='u2').tobytes())
+        vao = self.ctx.simple_vertex_array(prog, vbo1, 'in_vert', index_buffer=index, index_element_size=2)
+        vao.transform(vbo2, moderngl.POINTS)
+        res = np.frombuffer(vbo2.read(), dtype='f4')
+        np.testing.assert_almost_equal(res, vertices * count)
+
+        # UNSIGNED_BYTE index
+        vbo1 = self.ctx.buffer(np.array(vertices, dtype='f4').tobytes())
+        vbo2 = self.ctx.buffer(reserve=vbo1.size * count)
+        index = self.ctx.buffer(np.array(indices, dtype='u1').tobytes())
+        vao = self.ctx.simple_vertex_array(prog, vbo1, 'in_vert', index_buffer=index, index_element_size=1)
+        vao.transform(vbo2, moderngl.POINTS)
+        res = np.frombuffer(vbo2.read(), dtype='f4')
+        np.testing.assert_almost_equal(res, vertices * count)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Description

Support `UNSIGNED_INT`, `UNSIGNED_SHORT` and `UNSIGNED_BYTE` index buffers in VertexArray.
Added an optional `index_element_size` parameter (default: 4) were users can specify this. It can be 1, 2 or 4. 