### PR TITLE
Don't call DrawBuffers on default framebuffer

### DIFF
--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -1324,8 +1324,6 @@ void MGLContext_Initialize(MGLContext * self) {
 		MGLFramebuffer * framebuffer = (MGLFramebuffer *)MGLFramebuffer_Type.tp_alloc(&MGLFramebuffer_Type, 0);
 
 		framebuffer->framebuffer_obj = 0;
-
-		framebuffer->draw_buffers_len = 1;
 		framebuffer->draw_buffers = new unsigned[1];
 
 		// According to glGet docs:

--- a/src/Framebuffer.cpp
+++ b/src/Framebuffer.cpp
@@ -375,8 +375,9 @@ PyObject * MGLFramebuffer_clear(MGLFramebuffer * self, PyObject * args) {
 	const GLMethods & gl = self->context->gl;
 
 	gl.BindFramebuffer(GL_FRAMEBUFFER, self->framebuffer_obj);
-	if (self->framebuffer_obj > 0)
+	if (self->framebuffer_obj > 0) {
 		gl.DrawBuffers(self->draw_buffers_len, self->draw_buffers);
+	}
 	gl.ClearColor(r, g, b, a);
 	gl.ClearDepth(depth);
 

--- a/src/Framebuffer.cpp
+++ b/src/Framebuffer.cpp
@@ -375,7 +375,8 @@ PyObject * MGLFramebuffer_clear(MGLFramebuffer * self, PyObject * args) {
 	const GLMethods & gl = self->context->gl;
 
 	gl.BindFramebuffer(GL_FRAMEBUFFER, self->framebuffer_obj);
-	gl.DrawBuffers(self->draw_buffers_len, self->draw_buffers);
+	if (self->framebuffer_obj > 0)
+		gl.DrawBuffers(self->draw_buffers_len, self->draw_buffers);
 	gl.ClearColor(r, g, b, a);
 	gl.ClearDepth(depth);
 


### PR DESCRIPTION
### Description

Don't call ``DrawBuffers`` on the default framebuffer as it triggers ``INVALID_ENUM`` #212 