### PR TITLE
Sampler object support

### DIFF
--- a/docs/reference/context.rst
+++ b/docs/reference/context.rst
@@ -31,6 +31,7 @@ ModernGL Objects
 .. automethod:: Context.scope(framebuffer, enable_only=None, textures=(), uniform_buffers=(), storage_buffers=()) -> Scope
 .. automethod:: Context.query(samples=False, any_samples=False, time=False, primitives=False) -> Query
 .. automethod:: Context.compute_shader(source) -> ComputeShader
+.. automethod:: Context.sampler(repeat_x=True, repeat_y=True, filter=None, anisotropy=1.0, compare_func='') -> Sampler
 
 Methods
 -------
@@ -61,6 +62,7 @@ Attributes
 .. autoattribute:: Context.max_integer_samples
 .. autoattribute:: Context.max_texture_units
 .. autoattribute:: Context.default_texture_unit
+.. autoattribute:: Context.max_anisotropy
 .. autoattribute:: Context.multisample
 .. autoattribute:: Context.patch_vertices
 .. autoattribute:: Context.error

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -9,6 +9,7 @@ Reference
     vertex_array.rst
     program.rst
     texture.rst
+    texture_array.rst
     texture3d.rst
     texture_cube.rst
     framebuffer.rst

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -17,3 +17,4 @@ Reference
     query.rst
     conditional_render.rst
     compute_shader.rst
+    sampler.rst

--- a/docs/reference/sampler.rst
+++ b/docs/reference/sampler.rst
@@ -1,0 +1,27 @@
+Sampler
+=======
+
+.. py:module:: moderngl
+.. py:currentmodule:: moderngl
+
+.. autoclass:: moderngl.Sampler
+
+Create
+======
+
+.. automethod:: Context.sampler(repeat_x=True, repeat_y=True, filter=None, anisotropy=1.0, compare_func='') -> Sampler
+
+Methods
+-------
+
+.. automethod:: Sampler.use(location=0)
+.. automethod:: Sampler.release()
+
+Attributes
+----------
+
+.. autoattribute:: Sampler.repeat_x
+.. autoattribute:: Sampler.repeat_y
+.. autoattribute:: Sampler.filter
+.. autoattribute:: Sampler.compare_func
+.. autoattribute:: Sampler.anisotropy

--- a/docs/reference/sampler.rst
+++ b/docs/reference/sampler.rst
@@ -7,7 +7,7 @@ Sampler
 .. autoclass:: moderngl.Sampler
 
 Create
-======
+------
 
 .. automethod:: Context.sampler(repeat_x=True, repeat_y=True, filter=None, anisotropy=1.0, compare_func='') -> Sampler
 

--- a/docs/reference/sampler.rst
+++ b/docs/reference/sampler.rst
@@ -15,6 +15,7 @@ Methods
 -------
 
 .. automethod:: Sampler.use(location=0)
+.. automethod:: Sampler.clear(location=0)
 .. automethod:: Sampler.release()
 
 Attributes

--- a/docs/reference/texture.rst
+++ b/docs/reference/texture.rst
@@ -32,6 +32,7 @@ Attributes
 .. autoattribute:: Texture.filter
 .. autoattribute:: Texture.swizzle
 .. autoattribute:: Texture.compare_func
+.. autoattribute:: Texture.anisotropy
 .. autoattribute:: Texture.width
 .. autoattribute:: Texture.height
 .. autoattribute:: Texture.size

--- a/docs/reference/texture_array.rst
+++ b/docs/reference/texture_array.rst
@@ -28,6 +28,7 @@ Attributes
 .. autoattribute:: TextureArray.repeat_y
 .. autoattribute:: TextureArray.filter
 .. autoattribute:: TextureArray.swizzle
+.. autoattribute:: TextureArray.anisotropy
 .. autoattribute:: TextureArray.width
 .. autoattribute:: TextureArray.height
 .. autoattribute:: TextureArray.layers

--- a/docs/reference/texture_cube.rst
+++ b/docs/reference/texture_cube.rst
@@ -23,6 +23,12 @@ Methods
 Attributes
 ----------
 
+.. autoattribute:: TextureCube.size
+.. autoattribute:: TextureCube.dtype
+.. autoattribute:: TextureCube.components
+.. autoattribute:: TextureCube.filter
+.. autoattribute:: TextureCube.swizzle
+.. autoattribute:: TextureCube.anisotropy
 .. autoattribute:: TextureCube.glo
 
 .. toctree::

--- a/moderngl/__init__.py
+++ b/moderngl/__init__.py
@@ -19,6 +19,8 @@ from .texture_3d import *
 from .texture_array import *
 from .texture_cube import *
 from .vertex_array import *
+from .sampler import *
+
 
 import os
 if os.environ.get('READTHEDOCS') == 'True':

--- a/moderngl/context.py
+++ b/moderngl/context.py
@@ -485,7 +485,7 @@ class Context:
             Create a :py:class:`TextureCube` object.
 
             Args:
-                size (tuple): The width, height and depth of the texture.
+                size (tuple): The width, height of the texture. Each side of the cube will have this size.
                 components (int): The number of components 1, 2, 3 or 4.
                 data (bytes): Content of the texture.
 

--- a/moderngl/context.py
+++ b/moderngl/context.py
@@ -18,6 +18,7 @@ from .texture_3d import Texture3D
 from .texture_array import TextureArray
 from .texture_cube import TextureCube
 from .vertex_array import VertexArray
+from .sampler import Sampler
 
 __all__ = ['Context', 'create_context', 'create_standalone_context',
            'NOTHING', 'BLEND', 'DEPTH_TEST', 'CULL_FACE', 'RASTERIZER_DISCARD',
@@ -793,6 +794,16 @@ class Context:
 
         res = ComputeShader.__new__(ComputeShader)
         res.mglo, res._glo = self.mglo.compute_shader(source)
+        res.ctx = self
+        return res
+
+    def sampler(self, repeat_x: bool, repeat_y: bool, filter: Tuple[int, int], compare_func: str) -> Sampler:
+        '''
+            Docstring
+        '''
+
+        res = Sampler.__new__(Sampler)
+        res.mglo, res._glo = self.mglo.sampler()
         res.ctx = self
         return res
 

--- a/moderngl/context.py
+++ b/moderngl/context.py
@@ -804,8 +804,7 @@ class Context:
         res.ctx = self
         return res
 
-    def sampler(self, repeat_x: bool=True, repeat_y: bool=True, filter: Tuple[int, int]=(9729, 9729),
-                anisotropy: float=1.0, compare_func: str='=<') -> Sampler:
+    def sampler(self, repeat_x=True, repeat_y=True, filter=None, anisotropy=1.0, compare_func='') -> Sampler:
         '''
             Create a sampler object.
             When a sampler object is bound to a texture image unit, the internal sampling parameters for a
@@ -825,7 +824,8 @@ class Context:
         res.ctx = self
         res.repeat_x = repeat_x
         res.repeat_y = repeat_y
-        res.filter = filter
+        if filter is not None:
+            res.filter = filter
         res.anisotropy = anisotropy
         res.compare_func = compare_func
         return res

--- a/moderngl/context.py
+++ b/moderngl/context.py
@@ -806,16 +806,13 @@ class Context:
 
     def sampler(self, repeat_x=True, repeat_y=True, filter=None, anisotropy=1.0, compare_func='') -> Sampler:
         '''
-            Create a sampler object.
-            When a sampler object is bound to a texture image unit, the internal sampling parameters for a
-            texture bound to the same image unit are all ignored. Instead, the sampling parameters are taken
-            from this sampler object.
+            Create a :py:class:`Sampler` object.
 
             Keyword Arguments:
                 repeat_x (bool): Repeat texture on x
                 repeat_x (bool): Repeat texture on y
                 filter (tuple): The min and max filter
-                anisotropy (float): Number of samples for anisotropic filtering. Any value greater than 1.0f counts as a use of anisotropic filtering.
+                anisotropy (float): Number of samples for anisotropic filtering. Any value greater than 1.0 counts as a use of anisotropic filtering
                 compare_func: Compare function for depth textures
         '''
 

--- a/moderngl/context.py
+++ b/moderngl/context.py
@@ -824,8 +824,7 @@ class Context:
         res.ctx = self
         res.repeat_x = repeat_x
         res.repeat_y = repeat_y
-        if filter is not None:
-            res.filter = filter
+        res.filter = filter or (9729, 9729)
         res.anisotropy = anisotropy
         res.compare_func = compare_func
         return res

--- a/moderngl/context.py
+++ b/moderngl/context.py
@@ -804,14 +804,30 @@ class Context:
         res.ctx = self
         return res
 
-    def sampler(self, repeat_x: bool, repeat_y: bool, filter: Tuple[int, int], compare_func: str) -> Sampler:
+    def sampler(self, repeat_x: bool=True, repeat_y: bool=True, filter: Tuple[int, int]=(9729, 9729),
+                anisotropy: float=1.0, compare_func: str='=<') -> Sampler:
         '''
-            Docstring
+            Create a sampler object.
+            When a sampler object is bound to a texture image unit, the internal sampling parameters for a
+            texture bound to the same image unit are all ignored. Instead, the sampling parameters are taken
+            from this sampler object.
+
+            Keyword Arguments:
+                repeat_x (bool): Repeat texture on x
+                repeat_x (bool): Repeat texture on y
+                filter (tuple): The min and max filter
+                anisotropy (float): Number of samples for anisotropic filtering. Any value greater than 1.0f counts as a use of anisotropic filtering.
+                compare_func: Compare function for depth textures
         '''
 
         res = Sampler.__new__(Sampler)
         res.mglo, res._glo = self.mglo.sampler()
         res.ctx = self
+        res.repeat_x = repeat_x
+        res.repeat_y = repeat_y
+        res.filter = filter
+        res.anisotropy = anisotropy
+        res.compare_func = compare_func
         return res
 
     def core_profile_check(self) -> None:

--- a/moderngl/context.py
+++ b/moderngl/context.py
@@ -186,6 +186,13 @@ class Context:
         self.mglo.default_texture_unit = value
 
     @property
+    def max_anisotropy(self):
+        '''
+            float: Max anisotropy
+        '''
+        return self.mglo.max_anisotropy
+
+    @property
     def screen(self) -> 'Framebuffer':
         '''
             Framebuffer: The default framebuffer.

--- a/moderngl/context.py
+++ b/moderngl/context.py
@@ -452,6 +452,9 @@ class Context:
 
         res = TextureArray.__new__(TextureArray)
         res.mglo, res._glo = self.mglo.texture_array(size, components, data, alignment, dtype)
+        res._size = size
+        res._components = components
+        res._dtype = dtype
         res.ctx = self
         return res
 

--- a/moderngl/sampler.py
+++ b/moderngl/sampler.py
@@ -1,0 +1,29 @@
+
+
+class Sampler:
+    '''
+        Docstring
+    '''
+
+    __slots__ = ['mglo', '_glo', 'ctx', 'extra']
+
+    def __init__(self):
+        self.mglo = None
+        self._glo = None
+        self.ctx = None
+        self.extra = None
+        raise TypeError()
+
+    @property
+    def bar(self) -> None:
+        return self.mglo.bar
+
+    @bar.setter
+    def bar(self, value):
+        self.mglo.bar = value
+
+    def foo(self) -> None:
+        self.mglo.foo()
+
+    def release(self) -> None:
+        self.mglo.release()

--- a/moderngl/sampler.py
+++ b/moderngl/sampler.py
@@ -1,8 +1,12 @@
+from typing import Tuple
 
 
 class Sampler:
     '''
-        Docstring
+        A Sampler Object is an OpenGL Object that stores the sampling parameters for a
+        Texture access inside of a shader. When a sampler object is bound to a texture image unit,
+        the internal sampling parameters for a texture bound to the same image unit are all ignored.
+        Instead, the sampling parameters are taken from this sampler object.
     '''
 
     __slots__ = ['mglo', '_glo', 'ctx', 'extra']
@@ -14,16 +18,57 @@ class Sampler:
         self.extra = None
         raise TypeError()
 
-    @property
-    def bar(self) -> None:
-        return self.mglo.bar
+    def use(self, location=0) -> None:
+        '''
+            Bind the sampler to a texture unit
 
-    @bar.setter
-    def bar(self, value):
-        self.mglo.bar = value
-
-    def foo(self) -> None:
-        self.mglo.foo()
+            Args:
+                location (int): The texture unit
+        '''
+        self.mglo.use(location)
 
     def release(self) -> None:
         self.mglo.release()
+
+    @property
+    def repeat_x(self) -> bool:
+        return self.mglo.repeat_x
+
+    @repeat_x.setter
+    def repeat_x(self, value: bool):
+        self.mglo.repeat_x = value
+
+    @property
+    def repeat_y(self) -> bool:
+        return self.mglo.repeat_x
+
+    @repeat_y.setter
+    def repeat_y(self, value: bool):
+        self.mglo.repeat_y = value
+
+    @property
+    def filter(self) -> Tuple[int, int]:
+        '''
+            tuple: The filter of the sampler
+        '''
+        return self.mglo.filter
+
+    @filter.setter
+    def filter(self, value: Tuple[int, int]):
+        self.mglo.filter = value
+
+    @property
+    def compare_func(self) -> str:
+        return self.mglo.compare_func
+
+    @compare_func.setter
+    def compare_func(self, value: str):
+        self.mglo.compare_func = value
+
+    @property
+    def anisotropy(self) -> float:
+        return self.mglo.anisotropy
+
+    @anisotropy.setter
+    def anisotropy(self, value: float):
+        self.mglo.anisotropy = value

--- a/moderngl/sampler.py
+++ b/moderngl/sampler.py
@@ -30,10 +30,16 @@ class Sampler:
         self.mglo.use(location)
 
     def release(self) -> None:
+        '''
+            Release the ModernGL object.
+        '''
         self.mglo.release()
 
     @property
     def repeat_x(self) -> bool:
+        '''
+            bool: The repeat_x of the texture.
+        '''
         return self.mglo.repeat_x
 
     @repeat_x.setter
@@ -42,6 +48,9 @@ class Sampler:
 
     @property
     def repeat_y(self) -> bool:
+        '''
+            bool: The repeat_y of the texture.
+        '''
         return self.mglo.repeat_x
 
     @repeat_y.setter
@@ -51,7 +60,7 @@ class Sampler:
     @property
     def filter(self) -> Tuple[int, int]:
         '''
-            tuple: The filter of the sampler
+            tuple: The filter of the sampler (min, mag)
         '''
         return self.mglo.filter
 
@@ -61,6 +70,9 @@ class Sampler:
 
     @property
     def compare_func(self) -> str:
+        '''
+            tuple: The compare function of the depth texture.
+        '''
         return self.mglo.compare_func
 
     @compare_func.setter
@@ -69,6 +81,9 @@ class Sampler:
 
     @property
     def anisotropy(self) -> float:
+        '''
+            float: Number of samples for anisotropic filtering. Any value greater than 1.0 counts as a use of anisotropic filtering
+        '''
         return self.mglo.anisotropy
 
     @anisotropy.setter

--- a/moderngl/sampler.py
+++ b/moderngl/sampler.py
@@ -1,5 +1,7 @@
 from typing import Tuple
 
+__all__ = ['Sampler']
+
 
 class Sampler:
     '''

--- a/moderngl/sampler.py
+++ b/moderngl/sampler.py
@@ -29,9 +29,18 @@ class Sampler:
         '''
         self.mglo.use(location)
 
+    def clear(self, location=0) -> None:
+        '''
+            Clear the sampler binding on a texture unit
+
+            Args:
+                location (int): The texture unit
+        '''
+        self.mglo.clear(location)
+
     def release(self) -> None:
         '''
-            Release the ModernGL object.
+            Release/destroy the ModernGL object.
         '''
         self.mglo.release()
 

--- a/moderngl/texture.py
+++ b/moderngl/texture.py
@@ -79,6 +79,18 @@ class Texture:
 
         return self.mglo.filter
 
+    @property
+    def anisotropy(self) -> float:
+        '''
+            float: Number of samples for anisotropic filtering.
+            Any value greater than 1.0 counts as a use of anisotropic filtering
+        '''
+        return self.mglo.anisotropy
+
+    @anisotropy.setter
+    def anisotropy(self, value):
+        self.mglo.anisotropy = value
+
     @filter.setter
     def filter(self, value):
         self.mglo.filter = value

--- a/moderngl/texture_array.py
+++ b/moderngl/texture_array.py
@@ -84,6 +84,18 @@ class TextureArray:
         self.mglo.swizzle = value
 
     @property
+    def anisotropy(self) -> float:
+        '''
+            float: Number of samples for anisotropic filtering.
+            Any value greater than 1.0 counts as a use of anisotropic filtering
+        '''
+        return self.mglo.anisotropy
+
+    @anisotropy.setter
+    def anisotropy(self, value):
+        self.mglo.anisotropy = value
+
+    @property
     def width(self) -> int:
         '''
             int: The width of the texture array.

--- a/moderngl/texture_cube.py
+++ b/moderngl/texture_cube.py
@@ -33,6 +33,63 @@ class TextureCube:
         return type(self) is type(other) and self.mglo is other.mglo
 
     @property
+    def size(self):
+        '''
+            tuple: The size of the texture.
+        '''
+        return self._size
+
+    @property
+    def components(self) -> int:
+        '''
+            int: The number of components of the texture.
+        '''
+        return self._components
+
+    @property
+    def dtype(self) -> str:
+        '''
+            str: Data type.
+        '''
+
+        return self._dtype
+
+    @property
+    def filter(self):
+        '''
+            tuple: The filter of the texture.
+        '''
+        return self.mglo.filter
+
+    @filter.setter
+    def filter(self, value):
+        self.mglo.filter = value
+
+    @property
+    def swizzle(self) -> str:
+        '''
+            str: The swizzle of the texture.
+        '''
+
+        return self.mglo.swizzle
+
+    @swizzle.setter
+    def swizzle(self, value):
+        self.mglo.swizzle = value
+
+    @property
+    def anisotropy(self):
+        '''
+            float: Number of samples for anisotropic filtering.
+            Any value greater than 1.0 counts as a use of anisotropic filtering
+        '''
+        return self.mglo.anisotropy
+
+    @anisotropy.setter
+    def anisotropy(self, value):
+        self.mglo.anisotropy = value
+
+    @property
     def glo(self) -> int:
         '''
             int: The internal OpenGL object.

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ mgl = Extension(
     extra_compile_args=extra_compile_args[target],
     extra_link_args=extra_linker_args[target],
     sources=[
+        'src/Sampler.cpp',
         'src/Attribute.cpp',
         'src/Buffer.cpp',
         'src/BufferFormat.cpp',

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -584,6 +584,10 @@ PyObject * MGLContext_get_max_texture_units(MGLContext * self) {
 	return PyLong_FromLong(self->max_texture_units);
 }
 
+PyObject * MGLContext_get_max_anisotropy(MGLContext * self) {
+	return PyFloat_FromDouble(self->max_anisotropy);
+}
+
 MGLFramebuffer * MGLContext_get_fbo(MGLContext * self) {
 	Py_INCREF(self->bound_framebuffer);
 	return self->bound_framebuffer;
@@ -1219,6 +1223,12 @@ PyGetSetDef MGLContext_tp_getseters[] = {
 	{(char *)"blend_func", (getter)MGLContext_get_depth_func, (setter)MGLContext_set_blend_func, 0, 0},
 	{(char *)"multisample", (getter)MGLContext_get_multisample, (setter)MGLContext_set_multisample, 0, 0},
 
+	{(char *)"default_texture_unit", (getter)MGLContext_get_default_texture_unit, (setter)MGLContext_set_default_texture_unit, 0, 0},
+	{(char *)"max_samples", (getter)MGLContext_get_max_samples, 0, 0, 0},
+	{(char *)"max_integer_samples", (getter)MGLContext_get_max_integer_samples, 0, 0, 0},
+	{(char *)"max_texture_units", (getter)MGLContext_get_max_texture_units, 0, 0, 0},
+	{(char *)"max_anisotropy", (getter)MGLContext_get_max_anisotropy, 0, 0, 0},
+
 	{(char *)"fbo", (getter)MGLContext_get_fbo, (setter)MGLContext_set_fbo, 0, 0},
 
 	{(char *)"wireframe", (getter)MGLContext_get_wireframe, (setter)MGLContext_set_wireframe, 0, 0},
@@ -1318,6 +1328,9 @@ void MGLContext_Initialize(MGLContext * self) {
 	self->max_texture_units = 0;
 	gl.GetIntegerv(GL_MAX_TEXTURE_IMAGE_UNITS, (GLint *)&self->max_texture_units);
 	self->default_texture_unit = self->max_texture_units - 1;
+
+	self->max_anisotropy = 0.0;
+	gl.GetFloatv(GL_MAX_TEXTURE_MAX_ANISOTROPY, (GLfloat *)&self->max_anisotropy);
 
 	int bound_framebuffer = 0;
 	gl.GetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &bound_framebuffer);

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -413,6 +413,7 @@ PyObject * MGLContext_depth_renderbuffer(MGLContext * self, PyObject * args);
 PyObject * MGLContext_compute_shader(MGLContext * self, PyObject * args);
 PyObject * MGLContext_query(MGLContext * self, PyObject * args);
 PyObject * MGLContext_scope(MGLContext * self, PyObject * args);
+PyObject * MGLContext_sampler(MGLContext * self, PyObject * args);
 
 PyObject * MGLContext_release(MGLContext * self) {
 	// TODO:
@@ -444,6 +445,7 @@ PyMethodDef MGLContext_tp_methods[] = {
 	{"compute_shader", (PyCFunction)MGLContext_compute_shader, METH_VARARGS, 0},
 	{"query", (PyCFunction)MGLContext_query, METH_VARARGS, 0},
 	{"scope", (PyCFunction)MGLContext_scope, METH_VARARGS, 0},
+	{"sampler", (PyCFunction)MGLContext_sampler, METH_VARARGS, 0},
 
 	{"release", (PyCFunction)MGLContext_release, METH_NOARGS, 0},
 

--- a/src/InlineMethods.hpp
+++ b/src/InlineMethods.hpp
@@ -1,5 +1,15 @@
 #pragma once
 
+#ifdef _MSC_VER
+    #define INLINE __inline
+
+    INLINE double fmax(double left, double right)
+    { return (left > right) ? left : right; }
+
+    INLINE double fmin(double left, double right)
+    { return (left < right) ? left : right; }
+#endif
+
 inline void clean_glsl_name(char * name, int & name_len) {
 	if (name_len && name[name_len - 1] == ']') {
 		name_len -= 1;

--- a/src/ModernGL.cpp
+++ b/src/ModernGL.cpp
@@ -367,6 +367,17 @@ bool MGL_InitializeModule(PyObject * module) {
 		PyModule_AddObject(module, "VertexArray", (PyObject *)&MGLVertexArray_Type);
 	}
 
+	{
+		if (PyType_Ready(&MGLSampler_Type) < 0) {
+			PyErr_Format(PyExc_ImportError, "Cannot register Sampler in %s (%s:%d)", __FUNCTION__, __FILE__, __LINE__);
+			return false;
+		}
+
+		Py_INCREF(&MGLSampler_Type);
+
+		PyModule_AddObject(module, "Sampler", (PyObject *)&MGLSampler_Type);
+	}
+
 	return true;
 }
 

--- a/src/OpenGL.hpp
+++ b/src/OpenGL.hpp
@@ -964,6 +964,8 @@ typedef GLvoid (GLAPI * PROC_glTextureBarrier)();
 #define GL_TEXTURE30                                                  0x84DE
 #define GL_TEXTURE31                                                  0x84DF
 #define GL_ACTIVE_TEXTURE                                             0x84E0
+#define GL_TEXTURE_MAX_ANISOTROPY                                     0x84FE
+#define GL_MAX_TEXTURE_MAX_ANISOTROPY                                 0x84FF
 #define GL_MULTISAMPLE                                                0x809D
 #define GL_SAMPLE_ALPHA_TO_COVERAGE                                   0x809E
 #define GL_SAMPLE_ALPHA_TO_ONE                                        0x809F

--- a/src/Sampler.cpp
+++ b/src/Sampler.cpp
@@ -162,6 +162,12 @@ int MGLSampler_set_compare_func(MGLSampler * self, PyObject * value) {
 	self->compare_func = compare_func_from_string(func);
 
 	const GLMethods & gl = self->context->gl;
+
+	if (self->compare_func == 0) {
+		gl.SamplerParameteri(self->sampler_obj, GL_TEXTURE_COMPARE_MODE, GL_NONE);
+	} else {
+		gl.SamplerParameteri(self->sampler_obj, GL_TEXTURE_COMPARE_MODE, GL_COMPARE_REF_TO_TEXTURE);
+	}
 	gl.SamplerParameteri(self->sampler_obj, GL_TEXTURE_COMPARE_FUNC, self->compare_func);
 
 	return 0;

--- a/src/Sampler.cpp
+++ b/src/Sampler.cpp
@@ -159,9 +159,10 @@ PyObject * MGLSampler_get_compare_func(MGLSampler * self) {
 
 int MGLSampler_set_compare_func(MGLSampler * self, PyObject * value) {
 	const char * func = PyUnicode_AsUTF8(value);
-	
+	self->compare_func = compare_func_from_string(func);
+
 	const GLMethods & gl = self->context->gl;
-	gl.SamplerParameteri(self->sampler_obj, GL_TEXTURE_COMPARE_FUNC, compare_func_from_string(func));
+	gl.SamplerParameteri(self->sampler_obj, GL_TEXTURE_COMPARE_FUNC, self->compare_func);
 
 	return 0;
 }

--- a/src/Sampler.cpp
+++ b/src/Sampler.cpp
@@ -1,0 +1,139 @@
+#include "Types.hpp"
+
+PyObject * MGLContext_sampler(MGLContext * self, PyObject * args) {
+	int args_ok = PyArg_ParseTuple(
+		args,
+		""
+	);
+
+	if (!args_ok) {
+		return 0;
+	}
+
+	const GLMethods & gl = self->gl;
+
+	MGLSampler * sampler = (MGLSampler *)MGLSampler_Type.tp_alloc(&MGLSampler_Type, 0);
+
+	sampler->sampler_obj = 0;
+
+	// TODO: impl sampler
+
+	Py_INCREF(self);
+	sampler->context = self;
+
+	Py_INCREF(sampler);
+
+	PyObject * result = PyTuple_New(2);
+	PyTuple_SET_ITEM(result, 0, (PyObject *)sampler);
+	PyTuple_SET_ITEM(result, 1, PyLong_FromLong(sampler->sampler_obj));
+	return result;
+}
+
+PyObject * MGLSampler_tp_new(PyTypeObject * type, PyObject * args, PyObject * kwargs) {
+	MGLSampler * self = (MGLSampler *)type->tp_alloc(type, 0);
+
+	if (self) {
+	}
+
+	return (PyObject *)self;
+}
+
+void MGLSampler_tp_dealloc(MGLSampler * self) {
+	MGLSampler_Type.tp_free((PyObject *)self);
+}
+
+PyObject * MGLSampler_foo(MGLContext * self, PyObject * args) {
+	int args_ok = PyArg_ParseTuple(
+		args,
+		""
+	);
+
+	if (!args_ok) {
+		return 0;
+	}
+
+	// TODO: impl sampler
+
+	Py_RETURN_NONE;
+}
+
+PyObject * MGLSampler_release(MGLSampler * self) {
+	MGLSampler_Invalidate(self);
+	Py_RETURN_NONE;
+}
+
+PyMethodDef MGLSampler_tp_methods[] = {
+	{"foo", (PyCFunction)MGLSampler_foo, METH_VARARGS, 0},
+	{"release", (PyCFunction)MGLSampler_release, METH_NOARGS, 0},
+	{0},
+};
+
+PyObject * MGLSampler_get_bar(MGLSampler * self) {
+	// TODO: impl sampler
+	Py_RETURN_NONE;
+}
+
+int MGLSampler_set_bar(MGLSampler * self, PyObject * value) {
+	// TODO: impl sampler
+	return 0;
+}
+
+PyGetSetDef MGLSampler_tp_getseters[] = {
+	{(char *)"bar", (getter)MGLSampler_get_bar, (setter)MGLSampler_set_bar, 0, 0},
+	{0},
+};
+
+PyTypeObject MGLSampler_Type = {
+	PyVarObject_HEAD_INIT(0, 0)
+	"mgl.Sampler",                                          // tp_name
+	sizeof(MGLSampler),                                     // tp_basicsize
+	0,                                                      // tp_itemsize
+	(destructor)MGLSampler_tp_dealloc,                      // tp_dealloc
+	0,                                                      // tp_print
+	0,                                                      // tp_getattr
+	0,                                                      // tp_setattr
+	0,                                                      // tp_reserved
+	0,                                                      // tp_repr
+	0,                                                      // tp_as_number
+	0,                                                      // tp_as_sequence
+	0,                                                      // tp_as_mapping
+	0,                                                      // tp_hash
+	0,                                                      // tp_call
+	0,                                                      // tp_str
+	0,                                                      // tp_getattro
+	0,                                                      // tp_setattro
+	0,                                                      // tp_as_buffer
+	Py_TPFLAGS_DEFAULT,                                     // tp_flags
+	0,                                                      // tp_doc
+	0,                                                      // tp_traverse
+	0,                                                      // tp_clear
+	0,                                                      // tp_richcompare
+	0,                                                      // tp_weaklistoffset
+	0,                                                      // tp_iter
+	0,                                                      // tp_iternext
+	MGLSampler_tp_methods,                                  // tp_methods
+	0,                                                      // tp_members
+	MGLSampler_tp_getseters,                                // tp_getset
+	0,                                                      // tp_base
+	0,                                                      // tp_dict
+	0,                                                      // tp_descr_get
+	0,                                                      // tp_descr_set
+	0,                                                      // tp_dictoffset
+	0,                                                      // tp_init
+	0,                                                      // tp_alloc
+	MGLSampler_tp_new,                                      // tp_new
+};
+
+void MGLSampler_Invalidate(MGLSampler * sampler) {
+	if (Py_TYPE(sampler) == &MGLInvalidObject_Type) {
+		return;
+	}
+
+	// TODO: decref
+
+	const GLMethods & gl = sampler->context->gl;
+	gl.DeleteSamplers(1, (GLuint *)&sampler->sampler_obj);
+
+	Py_TYPE(sampler) = &MGLInvalidObject_Type;
+	Py_DECREF(sampler);
+}

--- a/src/Sampler.cpp
+++ b/src/Sampler.cpp
@@ -67,6 +67,25 @@ PyObject * MGLSampler_use(MGLSampler * self, PyObject * args) {
 	Py_RETURN_NONE;
 }
 
+PyObject * MGLSampler_clear(MGLSampler * self, PyObject * args) {
+	int index;
+
+	int args_ok = PyArg_ParseTuple(
+		args,
+		"I",
+		&index
+	);
+
+	if (!args_ok) {
+		return 0;
+	}
+
+	const GLMethods & gl = self->context->gl;
+	gl.BindSampler(index, 0);
+
+	Py_RETURN_NONE;
+}
+
 PyObject * MGLSampler_release(MGLSampler * self) {
 	MGLSampler_Invalidate(self);
 	Py_RETURN_NONE;
@@ -74,6 +93,7 @@ PyObject * MGLSampler_release(MGLSampler * self) {
 
 PyMethodDef MGLSampler_tp_methods[] = {
 	{"use", (PyCFunction)MGLSampler_use, METH_VARARGS, 0},
+	{"clear", (PyCFunction)MGLSampler_clear, METH_VARARGS, 0},
 	{"release", (PyCFunction)MGLSampler_release, METH_NOARGS, 0},
 	{0},
 };

--- a/src/Texture.cpp
+++ b/src/Texture.cpp
@@ -869,10 +869,17 @@ int MGLTexture_set_compare_func(MGLTexture * self, PyObject * value) {
 		return -1;
 	}
 
+	self->compare_func = compare_func_from_string(func);
+
 	const GLMethods & gl = self->context->gl;
 	gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
 	gl.BindTexture(texture_target, self->texture_obj);
-	gl.TexParameteri(texture_target, GL_TEXTURE_COMPARE_FUNC, compare_func_from_string(func));
+	if (self->compare_func == 0) {
+		gl.TexParameteri(texture_target, GL_TEXTURE_COMPARE_MODE, GL_NONE);
+	} else {
+		gl.TexParameteri(texture_target, GL_TEXTURE_COMPARE_MODE, GL_COMPARE_REF_TO_TEXTURE);
+	}
+	gl.TexParameteri(texture_target, GL_TEXTURE_COMPARE_FUNC, self->compare_func);
 
 	return 0;
 }

--- a/src/Texture.cpp
+++ b/src/Texture.cpp
@@ -136,6 +136,7 @@ PyObject * MGLContext_texture(MGLContext * self, PyObject * args) {
 
 	texture->max_level = 0;
 	texture->compare_func = 0;
+	texture->anisotropy = 1.0;
 	texture->depth = false;
 
 	texture->min_filter = GL_LINEAR;
@@ -884,12 +885,30 @@ int MGLTexture_set_compare_func(MGLTexture * self, PyObject * value) {
 	return 0;
 }
 
+PyObject * MGLTexture_get_anisotropy(MGLTexture * self) {
+	return PyFloat_FromDouble(self->anisotropy);
+}
+
+int MGLTexture_set_anisotropy(MGLTexture * self, PyObject * value) {
+	self->anisotropy = fmin(fmax(PyFloat_AsDouble(value), 1.0), self->context->max_anisotropy);
+	int texture_target = self->samples ? GL_TEXTURE_2D_MULTISAMPLE : GL_TEXTURE_2D;
+
+	const GLMethods & gl = self->context->gl;
+
+	gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
+	gl.BindTexture(texture_target, self->texture_obj);
+	gl.TexParameterf(texture_target, GL_TEXTURE_MAX_ANISOTROPY, self->anisotropy);
+
+	return 0;
+}
+
 PyGetSetDef MGLTexture_tp_getseters[] = {
 	{(char *)"repeat_x", (getter)MGLTexture_get_repeat_x, (setter)MGLTexture_set_repeat_x, 0, 0},
 	{(char *)"repeat_y", (getter)MGLTexture_get_repeat_y, (setter)MGLTexture_set_repeat_y, 0, 0},
 	{(char *)"filter", (getter)MGLTexture_get_filter, (setter)MGLTexture_set_filter, 0, 0},
 	{(char *)"swizzle", (getter)MGLTexture_get_swizzle, (setter)MGLTexture_set_swizzle, 0, 0},
 	{(char *)"compare_func", (getter)MGLTexture_get_compare_func, (setter)MGLTexture_set_compare_func, 0, 0},
+	{(char *)"anisotropy", (getter)MGLTexture_get_anisotropy, (setter)MGLTexture_set_anisotropy, 0, 0},
 	{0},
 };
 

--- a/src/TextureArray.cpp
+++ b/src/TextureArray.cpp
@@ -636,11 +636,11 @@ int MGLTextureArray_set_swizzle(MGLTextureArray * self, PyObject * value, void *
 	return 0;
 }
 
-PyObject * MGLTextureArray_get_anisotropy(MGLTexture * self) {
+PyObject * MGLTextureArray_get_anisotropy(MGLTextureArray * self) {
 	return PyFloat_FromDouble(self->anisotropy);
 }
 
-int MGLTextureArray_set_anisotropy(MGLTexture * self, PyObject * value) {
+int MGLTextureArray_set_anisotropy(MGLTextureArray * self, PyObject * value) {
 	self->anisotropy = fmin(fmax(PyFloat_AsDouble(value), 1.0), self->context->max_anisotropy);
 
 	const GLMethods & gl = self->context->gl;

--- a/src/TextureArray.cpp
+++ b/src/TextureArray.cpp
@@ -124,6 +124,7 @@ PyObject * MGLContext_texture_array(MGLContext * self, PyObject * args) {
 
 	texture->repeat_x = true;
 	texture->repeat_y = true;
+	texture->anisotropy = 1.0;
 
 	Py_INCREF(self);
 	texture->context = self;
@@ -635,11 +636,28 @@ int MGLTextureArray_set_swizzle(MGLTextureArray * self, PyObject * value, void *
 	return 0;
 }
 
+PyObject * MGLTextureArray_get_anisotropy(MGLTexture * self) {
+	return PyFloat_FromDouble(self->anisotropy);
+}
+
+int MGLTextureArray_set_anisotropy(MGLTexture * self, PyObject * value) {
+	self->anisotropy = fmin(fmax(PyFloat_AsDouble(value), 1.0), self->context->max_anisotropy);
+
+	const GLMethods & gl = self->context->gl;
+
+	gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
+	gl.BindTexture(GL_TEXTURE_2D_ARRAY, self->texture_obj);
+	gl.TexParameterf(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MAX_ANISOTROPY, self->anisotropy);
+
+	return 0;
+}
+
 PyGetSetDef MGLTextureArray_tp_getseters[] = {
 	{(char *)"repeat_x", (getter)MGLTextureArray_get_repeat_x, (setter)MGLTextureArray_set_repeat_x, 0, 0},
 	{(char *)"repeat_y", (getter)MGLTextureArray_get_repeat_y, (setter)MGLTextureArray_set_repeat_y, 0, 0},
 	{(char *)"filter", (getter)MGLTextureArray_get_filter, (setter)MGLTextureArray_set_filter, 0, 0},
 	{(char *)"swizzle", (getter)MGLTextureArray_get_swizzle, (setter)MGLTextureArray_set_swizzle, 0, 0},
+	{(char *)"anisotropy", (getter)MGLTextureArray_get_anisotropy, (setter)MGLTextureArray_set_anisotropy, 0, 0},
 	{0},
 };
 

--- a/src/TextureCube.cpp
+++ b/src/TextureCube.cpp
@@ -136,6 +136,7 @@ PyObject * MGLContext_texture_cube(MGLContext * self, PyObject * args) {
 	texture->min_filter = GL_LINEAR;
 	texture->mag_filter = GL_LINEAR;
 	texture->max_level = 0;
+	texture->anisotropy = 1.0;
 
 	Py_INCREF(self);
 	texture->context = self;
@@ -554,9 +555,26 @@ int MGLTextureCube_set_swizzle(MGLTextureCube * self, PyObject * value, void * c
 	return 0;
 }
 
+PyObject * MGLTextureCube_get_anisotropy(MGLTextureCube * self) {
+	return PyFloat_FromDouble(self->anisotropy);
+}
+
+int MGLTextureCube_set_anisotropy(MGLTextureCube * self, PyObject * value) {
+	self->anisotropy = fmin(fmax(PyFloat_AsDouble(value), 1.0), self->context->max_anisotropy);
+
+	const GLMethods & gl = self->context->gl;
+
+	gl.ActiveTexture(GL_TEXTURE0 + self->context->default_texture_unit);
+	gl.BindTexture(GL_TEXTURE_CUBE_MAP, self->texture_obj);
+	gl.TexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MAX_ANISOTROPY, self->anisotropy);
+
+	return 0;
+}
+
 PyGetSetDef MGLTextureCube_tp_getseters[] = {
 	{(char *)"filter", (getter)MGLTextureCube_get_filter, (setter)MGLTextureCube_set_filter, 0, 0},
 	{(char *)"swizzle", (getter)MGLTextureCube_get_swizzle, (setter)MGLTextureCube_set_swizzle, 0, 0},
+	{(char *)"anisotropy", (getter)MGLTextureCube_get_anisotropy, (setter)MGLTextureCube_set_anisotropy, 0, 0},
 	{0},
 };
 

--- a/src/Types.hpp
+++ b/src/Types.hpp
@@ -379,7 +379,14 @@ struct MGLSampler {
 	MGLContext * context;
 	int sampler_obj;
 
-	// TODO: impl sampler
+	int min_filter;
+	int mag_filter;
+	float anisotropy;
+
+	int compare_func;
+
+	bool repeat_x;
+	bool repeat_y;
 };
 
 MGLDataType * from_dtype(const char * dtype);

--- a/src/Types.hpp
+++ b/src/Types.hpp
@@ -251,6 +251,7 @@ struct MGLTexture {
 	int max_level;
 
 	int compare_func;
+	int anisotropy;
 
 	bool depth;
 

--- a/src/Types.hpp
+++ b/src/Types.hpp
@@ -48,6 +48,7 @@ struct MGLTextureCube;
 struct MGLUniform;
 struct MGLUniformBlock;
 struct MGLVertexArray;
+struct MGLSampler;
 
 struct MGLDataType {
 	int * internal_format;
@@ -371,6 +372,15 @@ struct MGLVertexArray {
 	int num_vertices;
 };
 
+struct MGLSampler {
+	PyObject_HEAD
+
+	MGLContext * context;
+	int sampler_obj;
+
+	// TODO: impl sampler
+};
+
 MGLDataType * from_dtype(const char * dtype);
 
 void MGLAttribute_Invalidate(MGLAttribute * attribute);
@@ -386,6 +396,7 @@ void MGLTexture_Invalidate(MGLTexture * texture);
 void MGLTextureArray_Invalidate(MGLTextureArray * texture);
 void MGLUniform_Invalidate(MGLUniform * uniform);
 void MGLVertexArray_Invalidate(MGLVertexArray * vertex_array);
+void MGLSampler_Invalidate(MGLSampler * sampler);
 
 void MGLAttribute_Complete(MGLAttribute * attribute, const GLMethods & gl);
 void MGLUniform_Complete(MGLUniform * self, const GLMethods & gl);
@@ -411,3 +422,4 @@ extern PyTypeObject MGLTextureArray_Type;
 extern PyTypeObject MGLUniformBlock_Type;
 extern PyTypeObject MGLUniform_Type;
 extern PyTypeObject MGLVertexArray_Type;
+extern PyTypeObject MGLSampler_Type;

--- a/src/Types.hpp
+++ b/src/Types.hpp
@@ -115,6 +115,7 @@ struct MGLContext {
 
 	int max_texture_units;
 	int default_texture_unit;
+	float max_anisotropy;
 
 	int enable_flags;
 	int front_face;

--- a/src/Types.hpp
+++ b/src/Types.hpp
@@ -304,6 +304,7 @@ struct MGLTextureArray {
 
 	bool repeat_x;
 	bool repeat_y;
+	float anisotropy;
 };
 
 struct MGLTextureCube {

--- a/src/Types.hpp
+++ b/src/Types.hpp
@@ -324,6 +324,7 @@ struct MGLTextureCube {
 	int min_filter;
 	int mag_filter;
 	int max_level;
+	float anisotropy;
 };
 
 struct MGLUniform {

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -82,6 +82,8 @@ class TestCase(unittest.TestCase):
     def test_conditional_render_docs(self):
         self.validate('conditional_render.rst', 'ConditionalRender', ['mglo'])
 
+    def test_sampler_docs(self):
+        self.validate('sampler.rst', 'Sampler', ['release', 'mglo', 'glo', 'ctx', 'extra'])
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -46,6 +46,9 @@ class TestCase(unittest.TestCase):
     def test_texture_docs(self):
         self.validate('texture.rst', 'Texture', ['release', 'mglo', 'glo', 'ctx', 'extra'])
 
+    def test_texture_array_docs(self):
+        self.validate('texture_array.rst', 'TextureArray', ['release', 'mglo', 'glo', 'ctx', 'extra'])
+
     def test_texture3d_docs(self):
         self.validate('texture3d.rst', 'Texture3D', ['release', 'mglo', 'glo', 'ctx', 'extra'])
 

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -1,8 +1,23 @@
-import ctypes
-import moderngl_debugger
-import moderngl as mgl
+import unittest
 
-ctx = mgl.create_standalone_context()
-sampler = ctx.sampler()
-print(sampler.foo())
-print(sampler.bar)
+import moderngl
+
+from common import get_context
+
+
+class TestCase(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ctx = get_context()
+
+    def test_attributes(self):
+        sampler = self.ctx.sampler()
+
+        # Default values
+        assert sampler.anisotropy == 1.0
+        assert sampler.repeat_x is True
+        assert sampler.repeat_y is True
+        assert sampler.filter == (moderngl.LINEAR, moderngl.LINEAR)
+        print(sampler.compare_func)
+        assert sampler.compare_func == '?'

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -19,5 +19,17 @@ class TestCase(unittest.TestCase):
         assert sampler.repeat_x is True
         assert sampler.repeat_y is True
         assert sampler.filter == (moderngl.LINEAR, moderngl.LINEAR)
-        print(sampler.compare_func)
         assert sampler.compare_func == '?'
+
+        # Change values
+        sampler.anisotropy = 2.0
+        sampler.repeat_x = False
+        sampler.repeat_y = False
+        sampler.filter = (moderngl.NEAREST_MIPMAP_NEAREST, moderngl.NEAREST)
+        sampler.compare_func = "<="
+
+        assert sampler.anisotropy == 2.0
+        assert sampler.repeat_x is False
+        assert sampler.repeat_y is False
+        assert sampler.filter == (moderngl.NEAREST_MIPMAP_NEAREST, moderngl.NEAREST)
+        assert sampler.compare_func == "<="

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -1,0 +1,8 @@
+import ctypes
+import moderngl_debugger
+import moderngl as mgl
+
+ctx = mgl.create_standalone_context()
+sampler = ctx.sampler()
+print(sampler.foo())
+print(sampler.bar)

--- a/tests/test_texture_array.py
+++ b/tests/test_texture_array.py
@@ -1,0 +1,35 @@
+import unittest
+
+import moderngl
+
+from common import get_context
+
+
+class TestCase(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ctx = get_context()
+
+    def test_create(self):
+        size = (64, 32, 8)
+        texture = self.ctx.texture_array(size, 4)
+
+        # Basic attributes
+        assert texture.size == size
+        assert texture.width == 64
+        assert texture.height == 32
+        assert texture.layers == 8
+        assert texture.dtype == 'f1'
+        assert texture.components == 4
+
+        # Texture paramters
+        assert texture.repeat_x == True
+        assert texture.repeat_y == True
+        assert texture.filter == (moderngl.LINEAR, moderngl.LINEAR)
+        assert texture.swizzle == "RGBA"
+        print(texture.anisotropy)
+        assert texture.anisotropy == 1.0
+
+        texture.build_mipmaps()
+        assert texture.filter == (moderngl.LINEAR_MIPMAP_LINEAR, moderngl.LINEAR)

--- a/tests/test_texture_cube.py
+++ b/tests/test_texture_cube.py
@@ -1,5 +1,7 @@
 import unittest
 
+import moderngl
+
 from common import get_context
 
 
@@ -8,6 +10,15 @@ class TestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.ctx = get_context()
+
+    def test_0(self):
+        texture = self.ctx.texture_cube((16, 16), 4)
+        assert texture.size == (16, 16)
+        assert texture.components == 4
+        assert texture.filter == (moderngl.LINEAR, moderngl.LINEAR)
+        assert texture.anisotropy == 1.0
+        assert texture.swizzle == "RGBA"
+        assert texture.glo > 0
 
     def test_1(self):
         faces = [

--- a/tests/test_texture_new.py
+++ b/tests/test_texture_new.py
@@ -30,7 +30,10 @@ class TestCase(unittest.TestCase):
         self.ctx.texture((16, 16), 3, samples=2)
 
     def test_depth_texture(self):
-        self.ctx.depth_texture((16, 16))
+        dt = self.ctx.depth_texture((16, 16))
+        assert dt.compare_func == '<='
+        dt.compare_func = ''
+        assert dt.compare_func == '?'
 
     def test_multisample_depth_texture(self):
         # if self.ctx.max_samples < 2:


### PR DESCRIPTION
### Description

* Support sampler objects.
* Allow disabling compare mode for samplers and depth textures
* Added missing context attributes ``max_samples``, ``max_integer_samples``, ``max_texture_units``, ``default_texture_unit``
* Added ``max_anisotropy`` attribute to context
* Added anisotropy attributes to textures
* TextureArray did not set all attributes on creation + missing docs
* Documenatation
* ``compare_mode`` can be disabled for depth textures