### PR TITLE
Fix missing uniforms in ComputeShader

### DIFF
--- a/docs/reference/compute_shader.rst
+++ b/docs/reference/compute_shader.rst
@@ -16,6 +16,7 @@ Methods
 -------
 
 .. automethod:: ComputeShader.run(group_x=1, group_y=1, group_z=1)
+.. automethod:: ComputeShader.get(key, default) -> Union[Uniform, UniformBlock, Subroutine, Attribute, Varying]
 
 Attributes
 ----------

--- a/moderngl/compute_shader.py
+++ b/moderngl/compute_shader.py
@@ -1,3 +1,8 @@
+from typing import Tuple, Union
+
+from .program_members import (Attribute, Subroutine, Uniform, UniformBlock,
+                              Varying)
+
 __all__ = ['ComputeShader']
 
 
@@ -7,10 +12,11 @@ class ComputeShader:
         While it can do rendering, it is generally used for tasks not directly related to drawing.
     '''
 
-    __slots__ = ['mglo', '_glo', 'ctx', 'extra']
+    __slots__ = ['mglo', '_members', '_glo', 'ctx', 'extra']
 
     def __init__(self):
         self.mglo = None
+        self._members = {}
         self._glo = None
         self.ctx = None
         self.extra = None
@@ -21,6 +27,12 @@ class ComputeShader:
 
     def __eq__(self, other):
         return type(self) is type(other) and self.mglo is other.mglo
+
+    def __getitem__(self, key) -> Union[Uniform, UniformBlock, Subroutine, Attribute, Varying]:
+        return self._members[key]
+
+    def __iter__(self):
+        yield from self._members
 
     @property
     def source(self) -> str:
@@ -50,6 +62,20 @@ class ComputeShader:
         '''
 
         return self.mglo.run(group_x, group_y, group_z)
+
+    def get(self, key, default) -> Union[Uniform, UniformBlock, Subroutine, Attribute, Varying]:
+        '''
+            Returns a Uniform, UniformBlock, Subroutine, Attribute or Varying.
+
+            Args:
+                default: This is the value to be returned in case key does not exist.
+
+            Returns:
+                :py:class:`Uniform`, :py:class:`UniformBlock`, :py:class:`Subroutine`,
+                :py:class:`Attribute` or :py:class:`Varying`
+        '''
+
+        return self._members.get(key, default)
 
     def release(self) -> None:
         '''

--- a/moderngl/context.py
+++ b/moderngl/context.py
@@ -792,7 +792,21 @@ class Context:
         '''
 
         res = ComputeShader.__new__(ComputeShader)
-        res.mglo, res._glo = self.mglo.compute_shader(source)
+        res.mglo, ls1, ls2, ls3, ls4, res._glo = self.mglo.compute_shader(source)
+
+        members = {}
+
+        for item in ls1:
+            obj = Uniform.__new__(Uniform)
+            obj.mglo, obj._location, obj._array_length, obj._dimension, obj._name = item
+            members[obj.name] = obj
+
+        for item in ls2:
+            obj = UniformBlock.__new__(UniformBlock)
+            obj.mglo, obj._index, obj._size, obj._name = item
+            members[obj.name] = obj
+
+        res._members = members
         res.ctx = self
         return res
 

--- a/src/ComputeShader.cpp
+++ b/src/ComputeShader.cpp
@@ -222,9 +222,13 @@ PyObject * MGLContext_compute_shader(MGLContext * self, PyObject * args) {
 		}
 	}
 
-	PyObject * result = PyTuple_New(2);
+	PyObject * result = PyTuple_New(6);
 	PyTuple_SET_ITEM(result, 0, (PyObject *)compute_shader);
-	PyTuple_SET_ITEM(result, 1, PyLong_FromLong(compute_shader->program_obj));
+	PyTuple_SET_ITEM(result, 1, uniforms_lst);
+	PyTuple_SET_ITEM(result, 2, uniform_blocks_lst);
+	PyTuple_SET_ITEM(result, 3, subroutines_lst);
+	PyTuple_SET_ITEM(result, 4, subroutine_uniforms_lst);
+	PyTuple_SET_ITEM(result, 5, PyLong_FromLong(compute_shader->program_obj));
 	return result;
 }
 


### PR DESCRIPTION
### Description

Fixes #217 

### List of changes

- **fixed** missing uniforms and uniform blocks in ComputeShader

<!--

### Style for python files:

- Please use 4 spaces (not tabs).
- Please follow the pep8 style guide.

-->

<!-- Please add yourself to the README.md too! -->
