### PR TITLE
Missing sampler parameters

### DIFF
--- a/docs/reference/context.rst
+++ b/docs/reference/context.rst
@@ -31,7 +31,7 @@ ModernGL Objects
 .. automethod:: Context.scope(framebuffer, enable_only=None, textures=(), uniform_buffers=(), storage_buffers=()) -> Scope
 .. automethod:: Context.query(samples=False, any_samples=False, time=False, primitives=False) -> Query
 .. automethod:: Context.compute_shader(source) -> ComputeShader
-.. automethod:: Context.sampler(repeat_x=True, repeat_y=True, filter=None, anisotropy=1.0, compare_func='') -> Sampler
+.. automethod:: Context.sampler(repeat_x=True, repeat_y=True, repeat_z=True, filter=None, anisotropy=1.0, compare_func='', border_color=None) -> Sampler
 
 Methods
 -------

--- a/docs/reference/context.rst
+++ b/docs/reference/context.rst
@@ -31,7 +31,7 @@ ModernGL Objects
 .. automethod:: Context.scope(framebuffer, enable_only=None, textures=(), uniform_buffers=(), storage_buffers=()) -> Scope
 .. automethod:: Context.query(samples=False, any_samples=False, time=False, primitives=False) -> Query
 .. automethod:: Context.compute_shader(source) -> ComputeShader
-.. automethod:: Context.sampler(repeat_x=True, repeat_y=True, repeat_z=True, filter=None, anisotropy=1.0, compare_func='', border_color=None) -> Sampler
+.. automethod:: Context.sampler(repeat_x=True, repeat_y=True, repeat_z=True, filter=None, anisotropy=1.0, compare_func='', border_color=None, min_lod=-1000.0, max_lod=1000.0) -> Sampler
 
 Methods
 -------

--- a/docs/reference/context.rst
+++ b/docs/reference/context.rst
@@ -32,7 +32,7 @@ ModernGL Objects
 .. automethod:: Context.query(samples=False, any_samples=False, time=False, primitives=False) -> Query
 .. automethod:: Context.compute_shader(source) -> ComputeShader
 .. automethod:: Context.sampler(repeat_x=True, repeat_y=True, repeat_z=True, filter=None, anisotropy=1.0, compare_func='', border_color=None, min_lod=-1000.0, max_lod=1000.0) -> Sampler
-.. automethod:: Context.clear_samplers()
+.. automethod:: Context.clear_samplers(start=0, end=-1)
 
 Methods
 -------

--- a/docs/reference/context.rst
+++ b/docs/reference/context.rst
@@ -31,7 +31,7 @@ ModernGL Objects
 .. automethod:: Context.scope(framebuffer, enable_only=None, textures=(), uniform_buffers=(), storage_buffers=()) -> Scope
 .. automethod:: Context.query(samples=False, any_samples=False, time=False, primitives=False) -> Query
 .. automethod:: Context.compute_shader(source) -> ComputeShader
-.. automethod:: Context.sampler(repeat_x=True, repeat_y=True, repeat_z=True, filter=None, anisotropy=1.0, compare_func='', border_color=None, min_lod=-1000.0, max_lod=1000.0) -> Sampler
+.. automethod:: Context.sampler(repeat_x=True, repeat_y=True, repeat_z=True, filter=None, anisotropy=1.0, compare_func='?', border_color=None, min_lod=-1000.0, max_lod=1000.0) -> Sampler
 .. automethod:: Context.clear_samplers(start=0, end=-1)
 
 Methods

--- a/docs/reference/context.rst
+++ b/docs/reference/context.rst
@@ -32,6 +32,7 @@ ModernGL Objects
 .. automethod:: Context.query(samples=False, any_samples=False, time=False, primitives=False) -> Query
 .. automethod:: Context.compute_shader(source) -> ComputeShader
 .. automethod:: Context.sampler(repeat_x=True, repeat_y=True, repeat_z=True, filter=None, anisotropy=1.0, compare_func='', border_color=None, min_lod=-1000.0, max_lod=1000.0) -> Sampler
+.. automethod:: Context.clear_samplers()
 
 Methods
 -------

--- a/docs/reference/sampler.rst
+++ b/docs/reference/sampler.rst
@@ -9,7 +9,7 @@ Sampler
 Create
 ------
 
-.. automethod:: Context.sampler(repeat_x=True, repeat_y=True, repeat_z=True, filter=None, anisotropy=1.0, compare_func='', border_color=None) -> Sampler
+.. automethod:: Context.sampler(repeat_x=True, repeat_y=True, repeat_z=True, filter=None, anisotropy=1.0, compare_func='', border_color=None, min_lod=-1000.0, max_lod=1000.0) -> Sampler
 
 Methods
 -------
@@ -28,3 +28,5 @@ Attributes
 .. autoattribute:: Sampler.compare_func
 .. autoattribute:: Sampler.anisotropy
 .. autoattribute:: Sampler.border_color
+.. autoattribute:: Sampler.min_lod
+.. autoattribute:: Sampler.max_lod

--- a/docs/reference/sampler.rst
+++ b/docs/reference/sampler.rst
@@ -9,7 +9,7 @@ Sampler
 Create
 ------
 
-.. automethod:: Context.sampler(repeat_x=True, repeat_y=True, filter=None, anisotropy=1.0, compare_func='') -> Sampler
+.. automethod:: Context.sampler(repeat_x=True, repeat_y=True, repeat_z=True, filter=None, anisotropy=1.0, compare_func='', border_color=None) -> Sampler
 
 Methods
 -------
@@ -27,3 +27,4 @@ Attributes
 .. autoattribute:: Sampler.filter
 .. autoattribute:: Sampler.compare_func
 .. autoattribute:: Sampler.anisotropy
+.. autoattribute:: Sampler.border_color

--- a/docs/reference/sampler.rst
+++ b/docs/reference/sampler.rst
@@ -9,7 +9,7 @@ Sampler
 Create
 ------
 
-.. automethod:: Context.sampler(repeat_x=True, repeat_y=True, repeat_z=True, filter=None, anisotropy=1.0, compare_func='', border_color=None, min_lod=-1000.0, max_lod=1000.0) -> Sampler
+.. automethod:: Context.sampler(repeat_x=True, repeat_y=True, repeat_z=True, filter=None, anisotropy=1.0, compare_func='?', border_color=None, min_lod=-1000.0, max_lod=1000.0) -> Sampler
 
 Methods
 -------

--- a/docs/reference/sampler.rst
+++ b/docs/reference/sampler.rst
@@ -23,6 +23,7 @@ Attributes
 
 .. autoattribute:: Sampler.repeat_x
 .. autoattribute:: Sampler.repeat_y
+.. autoattribute:: Sampler.repeat_z
 .. autoattribute:: Sampler.filter
 .. autoattribute:: Sampler.compare_func
 .. autoattribute:: Sampler.anisotropy

--- a/moderngl/context.py
+++ b/moderngl/context.py
@@ -951,7 +951,7 @@ class Context:
         return res
 
     def sampler(self, repeat_x=True, repeat_y=True, repeat_z=True, filter=None, anisotropy=1.0,
-                compare_func='', border_color=None) -> Sampler:
+                compare_func='', border_color=None, min_lod=-1000.0, max_lod=1000.0) -> Sampler:
         '''
             Create a :py:class:`Sampler` object.
 
@@ -965,6 +965,10 @@ class Context:
                 border_color (tuple): The (r, g, b, a) color for the texture border.
                                       When this value is set the ``repeat_`` values are overriden
                                       setting the texture wrap to return the border color when outside ``[0, 1]`` range.
+                min_lod (float): Minimum level-of-detail parameter (Default ``-1000.0``).
+                                 This floating-point value limits the selection of highest resolution mipmap (lowest mipmap level)
+                max_lod (float): Minimum level-of-detail parameter (Default ``1000.0``).
+                                 This floating-point value limits the selection of the lowest resolution mipmap (highest mipmap level)
         '''
 
         res = Sampler.__new__(Sampler)
@@ -978,6 +982,8 @@ class Context:
         res.compare_func = compare_func
         if border_color:
             res.border_color = border_color
+        res.min_lod = min_lod
+        res.max_lod = max_lod
         return res
 
     def core_profile_check(self) -> None:

--- a/moderngl/context.py
+++ b/moderngl/context.py
@@ -986,13 +986,26 @@ class Context:
         res.max_lod = max_lod
         return res
 
-    def clear_samplers(self):
+    def clear_samplers(self, start=0, end=-1):
         '''
-            Unbinds samplers from all texture units.
+            Unbinds samplers from texture units.
             Lingering samplers can be a source of weird bugs.
             This methods provides a fairly brute force and efficient way to ensure all texture units are clear.
+
+            Keyword Arguments:
+
+                start (int): The texture unit index to start the clearing samplers
+                stop (int): The texture unit index to stop clearing samplers
+            
+            Example::
+
+                # Clear texture unit 0, 1, 2, 3, 4
+                ctx.clear_samplers(start=0, end=5)
+
+                # Clear texture unit 4, 5, 6, 7
+                ctx.clear_samplers(start=4, end=8)
         '''
-        self.mglo.clear_samplers()
+        return self.mglo.clear_samplers(start, end)
 
     def core_profile_check(self) -> None:
         '''

--- a/moderngl/context.py
+++ b/moderngl/context.py
@@ -986,6 +986,14 @@ class Context:
         res.max_lod = max_lod
         return res
 
+    def clear_samplers(self):
+        '''
+            Unbinds samplers from all texture units.
+            Lingering samplers can be a source of weird bugs.
+            This methods provides a fairly brute force and efficient way to ensure all texture units are clear.
+        '''
+        self.mglo.clear_samplers()
+
     def core_profile_check(self) -> None:
         '''
             Core profile check.

--- a/moderngl/context.py
+++ b/moderngl/context.py
@@ -950,16 +950,21 @@ class Context:
         res.ctx = self
         return res
 
-    def sampler(self, repeat_x=True, repeat_y=True, filter=None, anisotropy=1.0, compare_func='') -> Sampler:
+    def sampler(self, repeat_x=True, repeat_y=True, repeat_z=True, filter=None, anisotropy=1.0,
+                compare_func='', border_color=None) -> Sampler:
         '''
             Create a :py:class:`Sampler` object.
 
             Keyword Arguments:
                 repeat_x (bool): Repeat texture on x
-                repeat_x (bool): Repeat texture on y
+                repeat_y (bool): Repeat texture on y
+                repeat_z (bool): Repeat texture on z
                 filter (tuple): The min and max filter
                 anisotropy (float): Number of samples for anisotropic filtering. Any value greater than 1.0 counts as a use of anisotropic filtering
                 compare_func: Compare function for depth textures
+                border_color (tuple): The (r, g, b, a) color for the texture border.
+                                      When this value is set the ``repeat_`` values are overriden
+                                      setting the texture wrap to return the border color when outside ``[0, 1]`` range.
         '''
 
         res = Sampler.__new__(Sampler)
@@ -967,9 +972,12 @@ class Context:
         res.ctx = self
         res.repeat_x = repeat_x
         res.repeat_y = repeat_y
+        res.repeat_z = repeat_z
         res.filter = filter or (9729, 9729)
         res.anisotropy = anisotropy
         res.compare_func = compare_func
+        if border_color:
+            res.border_color = border_color
         return res
 
     def core_profile_check(self) -> None:

--- a/moderngl/context.py
+++ b/moderngl/context.py
@@ -989,8 +989,9 @@ class Context:
     def clear_samplers(self, start=0, end=-1):
         '''
             Unbinds samplers from texture units.
-            Lingering samplers can be a source of weird bugs.
-            This methods provides a fairly brute force and efficient way to ensure all texture units are clear.
+            Sampler bindings do clear automatically between every frame,
+            but lingering samplers can still be a source of weird bugs during the frame rendering.
+            This methods provides a fairly brute force and efficient way to ensure texture units are clear.
 
             Keyword Arguments:
 
@@ -1005,7 +1006,7 @@ class Context:
                 # Clear texture unit 4, 5, 6, 7
                 ctx.clear_samplers(start=4, end=8)
         '''
-        return self.mglo.clear_samplers(start, end)
+        self.mglo.clear_samplers(start, end)
 
     def core_profile_check(self) -> None:
         '''

--- a/moderngl/context.py
+++ b/moderngl/context.py
@@ -951,7 +951,7 @@ class Context:
         return res
 
     def sampler(self, repeat_x=True, repeat_y=True, repeat_z=True, filter=None, anisotropy=1.0,
-                compare_func='', border_color=None, min_lod=-1000.0, max_lod=1000.0) -> Sampler:
+                compare_func='?', border_color=None, min_lod=-1000.0, max_lod=1000.0) -> Sampler:
         '''
             Create a :py:class:`Sampler` object.
 

--- a/moderngl/sampler.py
+++ b/moderngl/sampler.py
@@ -178,3 +178,21 @@ class Sampler:
     @anisotropy.setter
     def anisotropy(self, value: float):
         self.mglo.anisotropy = value
+
+    @property
+    def border_color(self):
+        '''
+            border_color (tuple) – The (r, g, b, a) color for the texture border (Default ``(0.0, 0.0, 0.0, 0.0)``)
+            When setting this value the ``repeat_`` values are overriden setting the texture wrap to return
+            the border color when outside [0, 1] range.
+
+            Example::
+
+                # Red border color
+                sampler.border_color = (1.0, 0.0, 0.0, 0.0)
+        '''
+        return self.mglo.border_color
+
+    @border_color.setter
+    def border_color(self, value):
+        self.mglo.border_color = value

--- a/moderngl/sampler.py
+++ b/moderngl/sampler.py
@@ -83,11 +83,30 @@ class Sampler:
                 # Disable texture repeat (GL_CLAMP_TO_EDGE)
                 sampler.repeat_y = False
         '''
-        return self.mglo.repeat_x
+        return self.mglo.repeat_y
 
     @repeat_y.setter
     def repeat_y(self, value: bool):
         self.mglo.repeat_y = value
+
+    @property
+    def repeat_z(self) -> bool:
+        '''
+            bool: The z repeat flag for the sampler (Default ``True``)
+
+            Example::
+
+                # Enable texture repeat (GL_REPEAT)
+                sampler.repeat_z = True
+
+                # Disable texture repeat (GL_CLAMP_TO_EDGE)
+                sampler.repeat_z = False
+        '''
+        return self.mglo.repeat_z
+
+    @repeat_z.setter
+    def repeat_z(self, value: bool):
+        self.mglo.repeat_z = value
 
     @property
     def filter(self) -> Tuple[int, int]:

--- a/moderngl/sampler.py
+++ b/moderngl/sampler.py
@@ -196,3 +196,27 @@ class Sampler:
     @border_color.setter
     def border_color(self, value):
         self.mglo.border_color = value
+
+    @property
+    def min_lod(self):
+        '''
+            float: Minimum level-of-detail parameter (Default ``-1000.0``).
+                   This floating-point value limits the selection of highest resolution mipmap (lowest mipmap level)
+        '''
+        return self.mglo.min_lod
+
+    @min_lod.setter
+    def min_lod(self, value):
+        self.mglo.min_lod = value
+
+    @property
+    def max_lod(self):
+        '''
+            float: Minimum level-of-detail parameter (Default ``1000.0``).
+                   This floating-point value limits the selection of the lowest resolution mipmap (highest mipmap level)
+        '''
+        return self.mglo.max_lod
+
+    @max_lod.setter
+    def max_lod(self, value):
+        self.mglo.max_lod = value

--- a/moderngl/sampler.py
+++ b/moderngl/sampler.py
@@ -16,6 +16,9 @@ class Sampler:
         Samplers are bound to a texture unit and not a texture itself. Be careful with leaving
         samplers bound to texture units as it can cause texture incompletness issues
         (the texture bind is ignored).
+
+        Sampler bindings do clear automatically between every frame so a texture unit
+        need at least one bind/use per frame.
     '''
 
     __slots__ = ['mglo', '_glo', 'ctx', 'extra']

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -427,10 +427,7 @@ PyObject * MGLContext_clear_samplers(MGLContext * self, PyObject * args) {
 		gl.BindSampler(i, 0);
 	}
 
-	PyObject * res = PyTuple_New(2);
-	PyTuple_SET_ITEM(res, 0, PyLong_FromLong(start));
-	PyTuple_SET_ITEM(res, 1, PyLong_FromLong(end));
-	return res;
+	Py_RETURN_NONE;
 }
 
 PyObject * MGLContext_buffer(MGLContext * self, PyObject * args);

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -400,13 +400,37 @@ PyObject * MGLContext_detect_framebuffer(MGLContext * self, PyObject * args) {
 }
 
 PyObject * MGLContext_clear_samplers(MGLContext * self, PyObject * args) {
+	int start;
+	int end;
+
+	int args_ok = PyArg_ParseTuple(
+		args,
+		"ii",
+		&start,
+		&end
+	);
+
+	if (!args_ok) {
+		return 0;
+	}
+
+	start = max(start, 0);
+	if (end == -1) {
+		end = self->max_texture_units;
+	} else {
+		end = min(end, self->max_texture_units);
+	}
+
 	const GLMethods & gl = self->gl;
 
-	for(int i = 0; i < self->max_texture_units; i++) {
+	for(int i = start; i < end; i++) {
 		gl.BindSampler(i, 0);
 	}
 
-	Py_RETURN_NONE;
+	PyObject * res = PyTuple_New(2);
+	PyTuple_SET_ITEM(res, 0, PyLong_FromLong(start));
+	PyTuple_SET_ITEM(res, 1, PyLong_FromLong(end));
+	return res;
 }
 
 PyObject * MGLContext_buffer(MGLContext * self, PyObject * args);

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -399,6 +399,16 @@ PyObject * MGLContext_detect_framebuffer(MGLContext * self, PyObject * args) {
 	return result;
 }
 
+PyObject * MGLContext_clear_samplers(MGLContext * self, PyObject * args) {
+	const GLMethods & gl = self->gl;
+
+	for(int i = 0; i < self->max_texture_units; i++) {
+		gl.BindSampler(i, 0);
+	}
+
+	Py_RETURN_NONE;
+}
+
 PyObject * MGLContext_buffer(MGLContext * self, PyObject * args);
 PyObject * MGLContext_texture(MGLContext * self, PyObject * args);
 PyObject * MGLContext_texture3d(MGLContext * self, PyObject * args);
@@ -429,6 +439,7 @@ PyMethodDef MGLContext_tp_methods[] = {
 	{"copy_buffer", (PyCFunction)MGLContext_copy_buffer, METH_VARARGS, 0},
 	{"copy_framebuffer", (PyCFunction)MGLContext_copy_framebuffer, METH_VARARGS, 0},
 	{"detect_framebuffer", (PyCFunction)MGLContext_detect_framebuffer, METH_VARARGS, 0},
+	{"clear_samplers", (PyCFunction)MGLContext_clear_samplers, METH_VARARGS, 0},
 
 	{"buffer", (PyCFunction)MGLContext_buffer, METH_VARARGS, 0},
 	{"texture", (PyCFunction)MGLContext_texture, METH_VARARGS, 0},

--- a/src/InlineMethods.hpp
+++ b/src/InlineMethods.hpp
@@ -1,13 +1,10 @@
 #pragma once
 
-#ifdef _MSC_VER
-    #define INLINE __inline
-
-    INLINE double fmax(double left, double right)
-    { return (left > right) ? left : right; }
-
-    INLINE double fmin(double left, double right)
-    { return (left < right) ? left : right; }
+#ifndef max
+#define max(a,b) (((a) > (b)) ? (a) : (b))
+#endif
+#ifndef min
+#define min(a,b) (((a) < (b)) ? (a) : (b))
 #endif
 
 inline void clean_glsl_name(char * name, int & name_len) {

--- a/src/Sampler.cpp
+++ b/src/Sampler.cpp
@@ -28,6 +28,8 @@ PyObject * MGLContext_sampler(MGLContext * self, PyObject * args) {
 	sampler->border_color[1] = 0.0;
 	sampler->border_color[2] = 0.0;
 	sampler->border_color[3] = 0.0;
+	sampler->min_lod = -1000.0;
+	sampler->max_lod = 1000.0;
 
 	Py_INCREF(self);
 	sampler->context = self;
@@ -260,8 +262,31 @@ int MGLSampler_set_border_color(MGLSampler * self, PyObject * value) {
 	return 0;
 }
 
-// GL_TEXTURE_MIN_LOD 
-// GL_TEXTURE_MAX_LOD
+PyObject * MGLSampler_get_min_lod(MGLSampler * self) {
+	return PyFloat_FromDouble(self->min_lod);
+}
+
+int MGLSampler_set_min_lod(MGLSampler * self, PyObject * value) {
+	self->min_lod = PyFloat_AsDouble(value);
+
+	const GLMethods & gl = self->context->gl;
+	gl.SamplerParameterf(self->sampler_obj, GL_TEXTURE_MIN_LOD, self->min_lod);
+
+	return 0;
+}
+
+PyObject * MGLSampler_get_max_lod(MGLSampler * self) {
+	return PyFloat_FromDouble(self->max_lod);
+}
+
+int MGLSampler_set_max_lod(MGLSampler * self, PyObject * value) {
+	self->max_lod = PyFloat_AsDouble(value);
+
+	const GLMethods & gl = self->context->gl;
+	gl.SamplerParameterf(self->sampler_obj, GL_TEXTURE_MAX_LOD, self->max_lod);
+
+	return 0;
+}
 
 PyGetSetDef MGLSampler_tp_getseters[] = {
 	{(char *)"repeat_x", (getter)MGLSampler_get_repeat_x, (setter)MGLSampler_set_repeat_x, 0, 0},
@@ -271,7 +296,8 @@ PyGetSetDef MGLSampler_tp_getseters[] = {
 	{(char *)"compare_func", (getter)MGLSampler_get_compare_func, (setter)MGLSampler_set_compare_func, 0, 0},
 	{(char *)"anisotropy", (getter)MGLSampler_get_anisotropy, (setter)MGLSampler_set_anisotropy, 0, 0},
 	{(char *)"border_color", (getter)MGLSampler_get_border_color, (setter)MGLSampler_set_border_color, 0, 0},
-
+	{(char *)"min_lod", (getter)MGLSampler_get_min_lod, (setter)MGLSampler_set_min_lod, 0, 0},
+	{(char *)"max_lod", (getter)MGLSampler_get_max_lod, (setter)MGLSampler_set_max_lod, 0, 0},
 	{0},
 };
 

--- a/src/Sampler.cpp
+++ b/src/Sampler.cpp
@@ -205,8 +205,8 @@ int MGLSampler_set_compare_func(MGLSampler * self, PyObject * value) {
 		gl.SamplerParameteri(self->sampler_obj, GL_TEXTURE_COMPARE_MODE, GL_NONE);
 	} else {
 		gl.SamplerParameteri(self->sampler_obj, GL_TEXTURE_COMPARE_MODE, GL_COMPARE_REF_TO_TEXTURE);
+		gl.SamplerParameteri(self->sampler_obj, GL_TEXTURE_COMPARE_FUNC, self->compare_func);
 	}
-	gl.SamplerParameteri(self->sampler_obj, GL_TEXTURE_COMPARE_FUNC, self->compare_func);
 
 	return 0;
 }

--- a/src/Sampler.cpp
+++ b/src/Sampler.cpp
@@ -22,6 +22,7 @@ PyObject * MGLContext_sampler(MGLContext * self, PyObject * args) {
 	sampler->anisotropy = 1.0;
 	sampler->repeat_x = true;
 	sampler->repeat_y = true;
+	sampler->repeat_z = true;
 	sampler->compare_func = 0;
 
 	Py_INCREF(self);
@@ -145,7 +146,28 @@ int MGLSampler_set_repeat_y(MGLSampler * self, PyObject * value) {
 		self->repeat_y = false;
 		return 0;
 	} else {
-		MGLError_Set("invalid value for texture_x");
+		MGLError_Set("invalid value for texture_y");
+		return -1;
+	}
+}
+
+PyObject * MGLSampler_get_repeat_z(MGLSampler * self) {
+	return PyBool_FromLong(self->repeat_z);
+}
+
+int MGLSampler_set_repeat_z(MGLSampler * self, PyObject * value) {
+	const GLMethods & gl = self->context->gl;
+
+	if (value == Py_True) {
+		gl.SamplerParameteri(self->sampler_obj, GL_TEXTURE_WRAP_R, GL_REPEAT);
+		self->repeat_z = true;
+		return 0;
+	} else if (value == Py_False) {
+		gl.SamplerParameteri(self->sampler_obj, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
+		self->repeat_z = false;
+		return 0;
+	} else {
+		MGLError_Set("invalid value for texture_z");
 		return -1;
 	}
 }
@@ -206,9 +228,12 @@ int MGLSampler_set_anisotropy(MGLSampler * self, PyObject * value) {
 	return 0;
 }
 
+
+
 PyGetSetDef MGLSampler_tp_getseters[] = {
 	{(char *)"repeat_x", (getter)MGLSampler_get_repeat_x, (setter)MGLSampler_set_repeat_x, 0, 0},
 	{(char *)"repeat_y", (getter)MGLSampler_get_repeat_y, (setter)MGLSampler_set_repeat_y, 0, 0},
+	{(char *)"repeat_z", (getter)MGLSampler_get_repeat_z, (setter)MGLSampler_set_repeat_z, 0, 0},
 	{(char *)"filter", (getter)MGLSampler_get_filter, (setter)MGLSampler_set_filter, 0, 0},
 	{(char *)"compare_func", (getter)MGLSampler_get_compare_func, (setter)MGLSampler_set_compare_func, 0, 0},
 	{(char *)"anisotropy", (getter)MGLSampler_get_anisotropy, (setter)MGLSampler_set_anisotropy, 0, 0},

--- a/src/Sampler.cpp
+++ b/src/Sampler.cpp
@@ -216,7 +216,7 @@ PyObject * MGLSampler_get_anisotropy(MGLSampler * self) {
 }
 
 int MGLSampler_set_anisotropy(MGLSampler * self, PyObject * value) {
-	self->anisotropy = fmin(fmax(PyFloat_AsDouble(value), 1.0), self->context->max_anisotropy);
+	self->anisotropy = min(max(PyFloat_AsDouble(value), 1.0), self->context->max_anisotropy);
 
 	const GLMethods & gl = self->context->gl;
 	gl.SamplerParameterf(self->sampler_obj, GL_TEXTURE_MAX_ANISOTROPY, self->anisotropy);

--- a/src/Texture.cpp
+++ b/src/Texture.cpp
@@ -880,7 +880,7 @@ PyObject * MGLTexture_get_anisotropy(MGLTexture * self) {
 }
 
 int MGLTexture_set_anisotropy(MGLTexture * self, PyObject * value) {
-	self->anisotropy = fmin(fmax(PyFloat_AsDouble(value), 1.0), self->context->max_anisotropy);
+	self->anisotropy = min(max(PyFloat_AsDouble(value), 1.0), self->context->max_anisotropy);
 	int texture_target = self->samples ? GL_TEXTURE_2D_MULTISAMPLE : GL_TEXTURE_2D;
 
 	const GLMethods & gl = self->context->gl;

--- a/src/TextureArray.cpp
+++ b/src/TextureArray.cpp
@@ -633,7 +633,7 @@ PyObject * MGLTextureArray_get_anisotropy(MGLTextureArray * self) {
 }
 
 int MGLTextureArray_set_anisotropy(MGLTextureArray * self, PyObject * value) {
-	self->anisotropy = fmin(fmax(PyFloat_AsDouble(value), 1.0), self->context->max_anisotropy);
+	self->anisotropy = min(max(PyFloat_AsDouble(value), 1.0), self->context->max_anisotropy);
 
 	const GLMethods & gl = self->context->gl;
 

--- a/src/TextureCube.cpp
+++ b/src/TextureCube.cpp
@@ -552,7 +552,7 @@ PyObject * MGLTextureCube_get_anisotropy(MGLTextureCube * self) {
 }
 
 int MGLTextureCube_set_anisotropy(MGLTextureCube * self, PyObject * value) {
-	self->anisotropy = fmin(fmax(PyFloat_AsDouble(value), 1.0), self->context->max_anisotropy);
+	self->anisotropy = min(max(PyFloat_AsDouble(value), 1.0), self->context->max_anisotropy);
 
 	const GLMethods & gl = self->context->gl;
 

--- a/src/Types.hpp
+++ b/src/Types.hpp
@@ -391,6 +391,7 @@ struct MGLSampler {
 
 	bool repeat_x;
 	bool repeat_y;
+	bool repeat_z;
 };
 
 MGLDataType * from_dtype(const char * dtype);

--- a/src/Types.hpp
+++ b/src/Types.hpp
@@ -392,6 +392,9 @@ struct MGLSampler {
 	bool repeat_x;
 	bool repeat_y;
 	bool repeat_z;
+
+	// border color
+	float border_color[4];
 };
 
 MGLDataType * from_dtype(const char * dtype);

--- a/src/Types.hpp
+++ b/src/Types.hpp
@@ -393,8 +393,10 @@ struct MGLSampler {
 	bool repeat_y;
 	bool repeat_z;
 
-	// border color
 	float border_color[4];
+
+	float min_lod;
+	float max_lod;
 };
 
 MGLDataType * from_dtype(const char * dtype);

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -15,21 +15,26 @@ class TestCase(unittest.TestCase):
         sampler = self.ctx.sampler()
 
         # Default values
-        assert sampler.anisotropy == 1.0
-        assert sampler.repeat_x is True
-        assert sampler.repeat_y is True
-        assert sampler.filter == (moderngl.LINEAR, moderngl.LINEAR)
-        assert sampler.compare_func == '?'
+        self.assertEqual(sampler.anisotropy, 1.0)
+        self.assertTrue(sampler.repeat_x)
+        self.assertTrue(sampler.repeat_y)
+        self.assertTrue(sampler.repeat_z)
+        self.assertEqual(sampler.filter, (moderngl.LINEAR, moderngl.LINEAR))
+        self.assertEqual(sampler.compare_func, '?')
 
         # Change values
-        sampler.anisotropy = 2.0
-        sampler.repeat_x = False
-        sampler.repeat_y = False
+        sampler.anisotropy = self.ctx.max_anisotropy
         sampler.filter = (moderngl.NEAREST_MIPMAP_NEAREST, moderngl.NEAREST)
         sampler.compare_func = "<="
 
-        assert sampler.anisotropy == 2.0
-        assert sampler.repeat_x is False
-        assert sampler.repeat_y is False
-        assert sampler.filter == (moderngl.NEAREST_MIPMAP_NEAREST, moderngl.NEAREST)
-        assert sampler.compare_func == "<="
+        self.assertEqual(sampler.anisotropy, self.ctx.max_anisotropy)
+        self.assertEqual(sampler.filter, (moderngl.NEAREST_MIPMAP_NEAREST, moderngl.NEAREST))
+        self.assertEqual(sampler.compare_func, "<=")
+
+        # Ensure repeat parameters are set correctly
+        sampler.repeat_x = False
+        self.assertEqual((sampler.repeat_x, sampler.repeat_y, sampler.repeat_z), (False, True, True))
+        sampler.repeat_y = False
+        self.assertEqual((sampler.repeat_x, sampler.repeat_y, sampler.repeat_z), (False, False, True))
+        sampler.repeat_z = False
+        self.assertEqual((sampler.repeat_x, sampler.repeat_y, sampler.repeat_z), (False, False, False))

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -62,4 +62,6 @@ class TestCase(unittest.TestCase):
         self.assertEqual(sampler.max_lod, 500.0)
 
     def test_clear_samplers(self):
-        self.ctx.clear_samplers()
+        self.ctx.clear_samplers(start=0, end=5)
+        self.ctx.clear_samplers(start=5, end=10)
+        self.ctx.clear_samplers(start=10, end=100)

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -4,14 +4,6 @@ import moderngl
 
 from common import get_context
 
-def checkerror(func):
-    def wrapper(*args, **kwargs):
-        _ = get_context().error
-        func(*args, **kwargs)
-        err = get_context().error
-        assert err == 'GL_NO_ERROR', "Error: %s" % err
-    return wrapper
-
 
 class TestCase(unittest.TestCase):
 
@@ -19,13 +11,11 @@ class TestCase(unittest.TestCase):
     def setUpClass(cls):
         cls.ctx = get_context()
 
-    @checkerror
     def test_create(self):
         sampler = self.ctx.sampler()
         sampler.use(location=0)
         sampler.clear(location=0)
 
-    @checkerror
     def test_defaults(self):
         sampler = self.ctx.sampler()
         self.assertEqual(sampler.anisotropy, 1.0)
@@ -38,7 +28,6 @@ class TestCase(unittest.TestCase):
         self.assertEqual(sampler.min_lod, -1000.0)
         self.assertEqual(sampler.max_lod, 1000.0)
 
-    @checkerror
     def test_prop_changes(self):
         sampler = self.ctx.sampler()
         # Change values
@@ -58,7 +47,6 @@ class TestCase(unittest.TestCase):
         sampler.repeat_z = False
         self.assertEqual((sampler.repeat_x, sampler.repeat_y, sampler.repeat_z), (False, False, False))
 
-    @checkerror
     def test_border_color(self):
         sampler = self.ctx.sampler()
 
@@ -73,7 +61,6 @@ class TestCase(unittest.TestCase):
             sampler.border_color = color
             self.assertEqual(sampler.border_color, color)
 
-    @checkerror
     def test_lod(self):
         sampler = self.ctx.sampler()
 
@@ -83,7 +70,6 @@ class TestCase(unittest.TestCase):
         sampler.max_lod = 500.0
         self.assertEqual(sampler.max_lod, 500.0)
 
-    @checkerror
     def test_clear_samplers(self):
         self.ctx.clear_samplers(start=0, end=5)
         self.ctx.clear_samplers(start=5, end=10)

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -60,3 +60,6 @@ class TestCase(unittest.TestCase):
 
         sampler.max_lod = 500.0
         self.assertEqual(sampler.max_lod, 500.0)
+
+    def test_clear_samplers(self):
+        self.ctx.clear_samplers()

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -50,3 +50,13 @@ class TestCase(unittest.TestCase):
         for color in colors:
             sampler.border_color = color
             self.assertEqual(sampler.border_color, color)
+
+        # LOD
+        self.assertEqual(sampler.min_lod, -1000.0)
+        self.assertEqual(sampler.max_lod, 1000.0)
+
+        sampler.min_lod = 0.0
+        self.assertEqual(sampler.min_lod, 0.0)
+
+        sampler.max_lod = 500.0
+        self.assertEqual(sampler.max_lod, 500.0)

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -21,6 +21,7 @@ class TestCase(unittest.TestCase):
         self.assertTrue(sampler.repeat_z)
         self.assertEqual(sampler.filter, (moderngl.LINEAR, moderngl.LINEAR))
         self.assertEqual(sampler.compare_func, '?')
+        self.assertEqual(sampler.border_color, (0.0, 0.0, 0.0, 0.0))
 
         # Change values
         sampler.anisotropy = self.ctx.max_anisotropy
@@ -38,3 +39,14 @@ class TestCase(unittest.TestCase):
         self.assertEqual((sampler.repeat_x, sampler.repeat_y, sampler.repeat_z), (False, False, True))
         sampler.repeat_z = False
         self.assertEqual((sampler.repeat_x, sampler.repeat_y, sampler.repeat_z), (False, False, False))
+
+        # Ensure border color values are set correctly
+        colors = [
+            (1.0, 0.0, 0.0, 0.0),
+            (0.0, 1.0, 0.0, 0.0),
+            (0.0, 0.0, 1.0, 0.0),
+            (0.0, 0.0, 0.0, 1.0),
+        ]
+        for color in colors:
+            sampler.border_color = color
+            self.assertEqual(sampler.border_color, color)


### PR DESCRIPTION
### Changes

* Bug: ``repeat_y`` was returning ``repeat_x`` in ``context.py``. Added tests for this.
* Bug: glError on sampler creation
* Added ``repeat_z``, ``min_lod``, ``max_lod`` and ``border_color``
* Added ``Context.clear_samplers``