### PR TITLE
Missing program_members package in release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,7 @@ setup(
     license='MIT',
     classifiers=classifiers,
     keywords=keywords,
-    packages=['moderngl'],
+    packages=['moderngl', 'moderngl.program_members'],
     install_requires=install_requires,
     ext_modules=[mgl],
     platforms=['any'],


### PR DESCRIPTION
### Description

The ``moderngl.program_members`` package is not included in the distributions.