### PR TITLE
Fix a regression in Context.cpp

### DIFF
--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -1372,7 +1372,7 @@ void MGLContext_Initialize(MGLContext * self) {
 
 		framebuffer->framebuffer_obj = 0;
 
-		framebuffer->draw_buffers_len = 0;
+		framebuffer->draw_buffers_len = 1;
 		framebuffer->draw_buffers = new unsigned[1];
 
 		// According to glGet docs:


### PR DESCRIPTION
framebuffer->draw_buffers_len was initialized to 0 instead of 1 in
MGLContext_Initialize().

This fixes #233.
