### PR TITLE
Properly handle flags when enter/exit scope

### DIFF
--- a/docs/reference/scope.rst
+++ b/docs/reference/scope.rst
@@ -46,7 +46,7 @@ Examples
 
     scope = ctx.scope(
         framebuffer=framebuffer1,
-        enable_flags=moderngl.BLEND,
+        enable_only=moderngl.BLEND,
         textures=[
             (texture1, 4),
             (texture2, 3),

--- a/moderngl/scope.py
+++ b/moderngl/scope.py
@@ -9,9 +9,9 @@ class Scope:
 
         - Set the enable flags.
         - Bind the framebuffer.
-        - Assing textures to texture locations.
-        - Assing buffers to uniform buffers.
-        - Assing buffers to shader storage buffers.
+        - Assigning textures to texture locations.
+        - Assigning buffers to uniform buffers.
+        - Assigning buffers to shader storage buffers.
 
         Responsibilities on exit:
 

--- a/src/Scope.cpp
+++ b/src/Scope.cpp
@@ -204,6 +204,8 @@ PyObject * MGLScope_end(MGLScope * self, PyObject * args) {
 	const GLMethods & gl = self->context->gl;
 	const int & flags = self->old_enable_flags;
 
+	self->context->enable_flags = self->old_enable_flags;
+
 	MGLFramebuffer_use(self->old_framebuffer);
 
 	if (flags & MGL_BLEND) {

--- a/src/Scope.cpp
+++ b/src/Scope.cpp
@@ -150,6 +150,9 @@ PyObject * MGLScope_begin(MGLScope * self, PyObject * args) {
 	const GLMethods & gl = self->context->gl;
 	const int & flags = self->enable_flags;
 
+	self->old_enable_flags = self->context->enable_flags;
+	self->context->enable_flags = self->enable_flags;
+
 	MGLFramebuffer_use(self->framebuffer);
 
 	for (int i = 0; i < self->num_textures; ++i) {


### PR DESCRIPTION
### Description

Fixes #237 

When entering a scope we update context with the new flags storing the old ones. Once the scope reverts we restore the old flags.
