### PR TITLE
Expose extra attributes + initialize

### DIFF
--- a/docs/reference/attribute.rst
+++ b/docs/reference/attribute.rst
@@ -11,6 +11,7 @@ Attribute
 .. autoattribute:: Attribute.dimension
 .. autoattribute:: Attribute.shape
 .. autoattribute:: Attribute.name
+.. autoattribute:: Attribute.extra
 
 .. toctree::
     :maxdepth: 2

--- a/docs/reference/buffer.rst
+++ b/docs/reference/buffer.rst
@@ -58,6 +58,7 @@ Attributes
 .. autoattribute:: Buffer.size
 .. autoattribute:: Buffer.dynamic
 .. autoattribute:: Buffer.glo
+.. autoattribute:: Buffer.extra
 
 .. toctree::
     :maxdepth: 2

--- a/docs/reference/compute_shader.rst
+++ b/docs/reference/compute_shader.rst
@@ -23,6 +23,7 @@ Attributes
 
 .. autoattribute:: ComputeShader.source
 .. autoattribute:: ComputeShader.glo
+.. autoattribute:: ComputeShader.extra
 
 .. toctree::
     :maxdepth: 2

--- a/docs/reference/context.rst
+++ b/docs/reference/context.rst
@@ -68,6 +68,7 @@ Attributes
 .. autoattribute:: Context.patch_vertices
 .. autoattribute:: Context.error
 .. autoattribute:: Context.info
+.. autoattribute:: Context.extra
 
 Examples
 --------

--- a/docs/reference/framebuffer.rst
+++ b/docs/reference/framebuffer.rst
@@ -37,6 +37,7 @@ Attributes
 .. autoattribute:: Framebuffer.color_attachments
 .. autoattribute:: Framebuffer.depth_attachment
 .. autoattribute:: Framebuffer.glo
+.. autoattribute:: Framebuffer.extra
 
 .. toctree::
     :maxdepth: 2

--- a/docs/reference/program.rst
+++ b/docs/reference/program.rst
@@ -25,6 +25,7 @@ Attributes
 .. autoattribute:: Program.geometry_vertices
 .. autoattribute:: Program.subroutines
 .. autoattribute:: Program.glo
+.. autoattribute:: Program.extra
 
 Examples
 --------

--- a/docs/reference/query.rst
+++ b/docs/reference/query.rst
@@ -19,6 +19,7 @@ Attributes
 .. autoattribute:: Query.primitives
 .. autoattribute:: Query.elapsed
 .. autoattribute:: Query.crender
+.. autoattribute:: Query.extra
 
 Examples
 --------

--- a/docs/reference/renderbuffer.rst
+++ b/docs/reference/renderbuffer.rst
@@ -26,6 +26,7 @@ Attributes
 .. autoattribute:: Renderbuffer.depth
 .. autoattribute:: Renderbuffer.dtype
 .. autoattribute:: Renderbuffer.glo
+.. autoattribute:: Renderbuffer.extra
 
 .. toctree::
     :maxdepth: 2

--- a/docs/reference/sampler.rst
+++ b/docs/reference/sampler.rst
@@ -30,3 +30,4 @@ Attributes
 .. autoattribute:: Sampler.border_color
 .. autoattribute:: Sampler.min_lod
 .. autoattribute:: Sampler.max_lod
+.. autoattribute:: Sampler.extra

--- a/docs/reference/scope.rst
+++ b/docs/reference/scope.rst
@@ -12,6 +12,11 @@ Create
 .. automethod:: Context.scope(framebuffer, enable_only=None, textures=(), uniform_buffers=(), storage_buffers=()) -> Scope
     :noindex:
 
+Attributes
+----------
+
+.. autoattribute:: Scope.extra
+
 Examples
 --------
 

--- a/docs/reference/subroutine.rst
+++ b/docs/reference/subroutine.rst
@@ -8,6 +8,7 @@ Subroutine
 
 .. autoattribute:: Subroutine.index
 .. autoattribute:: Subroutine.name
+.. autoattribute:: Subroutine.extra
 
 .. toctree::
     :maxdepth: 2

--- a/docs/reference/texture.rst
+++ b/docs/reference/texture.rst
@@ -41,6 +41,7 @@ Attributes
 .. autoattribute:: Texture.samples
 .. autoattribute:: Texture.depth
 .. autoattribute:: Texture.glo
+.. autoattribute:: Texture.extra
 
 .. toctree::
     :maxdepth: 2

--- a/docs/reference/texture3d.rst
+++ b/docs/reference/texture3d.rst
@@ -36,6 +36,7 @@ Attributes
 .. autoattribute:: Texture3D.dtype
 .. autoattribute:: Texture3D.components
 .. autoattribute:: Texture3D.glo
+.. autoattribute:: Texture3D.extra
 
 .. toctree::
     :maxdepth: 2

--- a/docs/reference/texture_array.rst
+++ b/docs/reference/texture_array.rst
@@ -36,6 +36,7 @@ Attributes
 .. autoattribute:: TextureArray.dtype
 .. autoattribute:: TextureArray.components
 .. autoattribute:: TextureArray.glo
+.. autoattribute:: TextureArray.extra
 
 .. toctree::
     :maxdepth: 2

--- a/docs/reference/texture_cube.rst
+++ b/docs/reference/texture_cube.rst
@@ -30,6 +30,7 @@ Attributes
 .. autoattribute:: TextureCube.swizzle
 .. autoattribute:: TextureCube.anisotropy
 .. autoattribute:: TextureCube.glo
+.. autoattribute:: TextureCube.extra
 
 .. toctree::
     :maxdepth: 2

--- a/docs/reference/uniform.rst
+++ b/docs/reference/uniform.rst
@@ -20,6 +20,7 @@ Attributes
 .. autoattribute:: Uniform.array_length
 .. autoattribute:: Uniform.name
 .. autoattribute:: Uniform.value
+.. autoattribute:: Uniform.extra
 
 .. toctree::
     :maxdepth: 2

--- a/docs/reference/uniform_block.rst
+++ b/docs/reference/uniform_block.rst
@@ -10,6 +10,7 @@ UniformBlock
 .. autoattribute:: UniformBlock.name
 .. autoattribute:: UniformBlock.index
 .. autoattribute:: UniformBlock.size
+.. autoattribute:: UniformBlock.extra
 
 .. toctree::
     :maxdepth: 2

--- a/docs/reference/varying.rst
+++ b/docs/reference/varying.rst
@@ -8,6 +8,7 @@ Varying
 
 .. autoattribute:: Varying.name
 .. autoattribute:: Varying.number
+.. autoattribute:: Varying.extra
 
 .. toctree::
     :maxdepth: 2

--- a/docs/reference/vertex_array.rst
+++ b/docs/reference/vertex_array.rst
@@ -38,6 +38,7 @@ Attributes
 .. autoattribute:: VertexArray.vertices
 .. autoattribute:: VertexArray.subroutines
 .. autoattribute:: VertexArray.glo
+.. autoattribute:: VertexArray.extra
 
 .. toctree::
     :maxdepth: 2

--- a/moderngl/buffer.py
+++ b/moderngl/buffer.py
@@ -22,7 +22,7 @@ class Buffer:
         self._dynamic = None
         self._glo = None
         self.ctx = None
-        self.extra = None
+        self.extra = None  #: Any - Attribute for storing user defined objects
         raise TypeError()
 
     def __repr__(self):

--- a/moderngl/compute_shader.py
+++ b/moderngl/compute_shader.py
@@ -19,7 +19,7 @@ class ComputeShader:
         self._members = {}
         self._glo = None
         self.ctx = None
-        self.extra = None
+        self.extra = None  #: Any - Attribute for storing user defined objects
         raise TypeError()
 
     def __repr__(self):

--- a/moderngl/context.py
+++ b/moderngl/context.py
@@ -68,7 +68,7 @@ class Context:
         self._info = None
         self.version_code = None  #: int: The OpenGL version code. Reports ``410`` for OpenGL 4.1
         self.fbo = None  #: Framebuffer: The active framebuffer. Set every time ``Framebuffer.use()`` is called.
-        self.extra = None
+        self.extra = None  #: Any - Attribute for storing user defined objects
         raise TypeError()
 
     def __repr__(self):
@@ -1062,6 +1062,7 @@ def create_context(require=None) -> Context:
     ctx.fbo = ctx.detect_framebuffer()
     ctx.mglo.fbo = ctx.fbo.mglo
     ctx._info = None
+    ctx.extra = None
 
     if require is not None and ctx.version_code < require:
         raise ValueError('The version required is not provided')
@@ -1097,6 +1098,7 @@ def create_standalone_context(require=None, **settings) -> 'Context':
     ctx._screen = None
     ctx.fbo = None
     ctx._info = None
+    ctx.extra = None
 
     if require is not None and ctx.version_code < require:
         raise ValueError('Requested OpenGL version {}, got version {}'.format(

--- a/moderngl/context.py
+++ b/moderngl/context.py
@@ -507,6 +507,7 @@ class Context:
         res._color_attachments = None
         res._depth_attachment = None
         res.ctx = self
+        res.extra = None
         return res
 
     def buffer(self, data=None, *, reserve=0, dynamic=False) -> Buffer:
@@ -531,6 +532,7 @@ class Context:
         res.mglo, res._size, res._glo = self.mglo.buffer(data, reserve, dynamic)
         res._dynamic = dynamic
         res.ctx = self
+        res.extra = None
         return res
 
     def texture(self, size, components, data=None, *, samples=0, alignment=1, dtype='f1') -> 'Texture':
@@ -559,6 +561,7 @@ class Context:
         res._dtype = dtype
         res._depth = False
         res.ctx = self
+        res.extra = None
         return res
 
     def texture_array(self, size, components, data=None, *, alignment=1, dtype='f1') -> 'TextureArray':
@@ -585,6 +588,7 @@ class Context:
         res._components = components
         res._dtype = dtype
         res.ctx = self
+        res.extra = None
         return res
 
     def texture3d(self, size, components, data=None, *, alignment=1, dtype='f1') -> 'Texture3D':
@@ -607,6 +611,7 @@ class Context:
         res = Texture3D.__new__(Texture3D)
         res.mglo, res._glo = self.mglo.texture3d(size, components, data, alignment, dtype)
         res.ctx = self
+        res.extra = None
         return res
 
     def texture_cube(self, size, components, data=None, *, alignment=1, dtype='f1') -> 'TextureCube':
@@ -632,6 +637,7 @@ class Context:
         res._components = components
         res._dtype = dtype
         res.ctx = self
+        res.extra = None
         return res
 
     def depth_texture(self, size, data=None, *, samples=0, alignment=4) -> 'Texture':
@@ -658,6 +664,7 @@ class Context:
         res._dtype = 'f4'
         res._depth = True
         res.ctx = self
+        res.extra = None
         return res
 
     def vertex_array(self, program, content,
@@ -688,6 +695,7 @@ class Context:
         res._index_buffer = index_buffer
         res._index_element_size = index_element_size
         res.ctx = self
+        res.extra = None
         return res
 
     def simple_vertex_array(self, program, buffer, *attributes,
@@ -772,6 +780,7 @@ class Context:
 
         res._members = members
         res.ctx = self
+        res.extra = None
         return res
 
     def query(self, *, samples=False, any_samples=False, time=False, primitives=False) -> 'Query':
@@ -794,6 +803,7 @@ class Context:
             res.crender.mglo = res.mglo
 
         res.ctx = self
+        res.extra = None
         return res
 
     def scope(self, framebuffer, enable_only=None, *, textures=(), uniform_buffers=(), storage_buffers=()) -> 'Scope':
@@ -817,6 +827,7 @@ class Context:
         res = Scope.__new__(Scope)
         res.mglo = self.mglo.scope(framebuffer.mglo, enable_only, textures, uniform_buffers, storage_buffers)
         res.ctx = self
+        res.extra = None
         return res
 
     def simple_framebuffer(self, size, components=4, *, samples=0, dtype='f1') -> 'Framebuffer':
@@ -865,6 +876,7 @@ class Context:
         res._color_attachments = tuple(color_attachments)
         res._depth_attachment = depth_attachment
         res.ctx = self
+        res.extra = None
         return res
 
     def renderbuffer(self, size, components=4, *, samples=0, dtype='f1') -> 'Renderbuffer':
@@ -892,6 +904,7 @@ class Context:
         res._dtype = dtype
         res._depth = False
         res.ctx = self
+        res.extra = None
         return res
 
     def depth_renderbuffer(self, size, *, samples=0) -> 'Renderbuffer':
@@ -917,6 +930,7 @@ class Context:
         res._dtype = 'f4'
         res._depth = True
         res.ctx = self
+        res.extra = None
         return res
 
     def compute_shader(self, source) -> 'ComputeShader':
@@ -948,6 +962,7 @@ class Context:
 
         res._members = members
         res.ctx = self
+        res.extra = None
         return res
 
     def sampler(self, repeat_x=True, repeat_y=True, repeat_z=True, filter=None, anisotropy=1.0,
@@ -984,6 +999,7 @@ class Context:
             res.border_color = border_color
         res.min_lod = min_lod
         res.max_lod = max_lod
+        res.extra = None
         return res
 
     def clear_samplers(self, start=0, end=-1):

--- a/moderngl/framebuffer.py
+++ b/moderngl/framebuffer.py
@@ -25,7 +25,7 @@ class Framebuffer:
         self._samples = None
         self._glo = None
         self.ctx = None
-        self.extra = None
+        self.extra = None  #: Any - Attribute for storing user defined objects
         raise TypeError()
 
     def __repr__(self):

--- a/moderngl/program.py
+++ b/moderngl/program.py
@@ -30,7 +30,7 @@ class Program:
         self._geom = (None, None, None)
         self._glo = None
         self.ctx = None
-        self.extra = None
+        self.extra = None  #: Any - Attribute for storing user defined objects
         raise TypeError()
 
     def __repr__(self):

--- a/moderngl/program_members/attribute.py
+++ b/moderngl/program_members/attribute.py
@@ -15,7 +15,7 @@ class Attribute:
         self._dimension = None
         self._shape = None
         self._name = None
-        self.extra = None
+        self.extra = None  #: Any - Attribute for storing user defined objects
         raise TypeError()
 
     def __repr__(self):

--- a/moderngl/program_members/subroutine.py
+++ b/moderngl/program_members/subroutine.py
@@ -11,7 +11,7 @@ class Subroutine:
     def __init__(self):
         self._index = None
         self._name = None
-        self.extra = None
+        self.extra = None  #: Any - Attribute for storing user defined objects
         raise TypeError()
 
     def __repr__(self):

--- a/moderngl/program_members/uniform.py
+++ b/moderngl/program_members/uniform.py
@@ -17,7 +17,7 @@ class Uniform:
         self._array_length = None
         self._dimension = None
         self._name = None
-        self.extra = None
+        self.extra = None  #: Any - Attribute for storing user defined objects
         raise TypeError()
 
     def __repr__(self):

--- a/moderngl/program_members/uniform_block.py
+++ b/moderngl/program_members/uniform_block.py
@@ -13,7 +13,7 @@ class UniformBlock:
         self._index = None
         self._size = None
         self._name = None
-        self.extra = None
+        self.extra = None  #: Any - Attribute for storing user defined objects
         raise TypeError()
 
     def __repr__(self):

--- a/moderngl/program_members/varying.py
+++ b/moderngl/program_members/varying.py
@@ -13,7 +13,7 @@ class Varying:
         self._array_length = None
         self._dimension = None
         self._name = None
-        self.extra = None
+        self.extra = None  #: Any - Attribute for storing user defined objects
         raise TypeError()
 
     def __repr__(self):

--- a/moderngl/query.py
+++ b/moderngl/query.py
@@ -12,7 +12,7 @@ class Query:
         self.mglo = None
         self.crender = None  #: ConditionalRender: Can be used in a ``with`` statement.
         self.ctx = None
-        self.extra = None
+        self.extra = None  #: Any - Attribute for storing user defined objects
         raise TypeError()
 
     def __repr__(self):

--- a/moderngl/renderbuffer.py
+++ b/moderngl/renderbuffer.py
@@ -26,7 +26,7 @@ class Renderbuffer:
         self._dtype = None
         self._glo = None
         self.ctx = None
-        self.extra = None
+        self.extra = None  #: Any - Attribute for storing user defined objects
         raise TypeError()
 
     def __repr__(self):

--- a/moderngl/sampler.py
+++ b/moderngl/sampler.py
@@ -27,7 +27,7 @@ class Sampler:
         self.mglo = None
         self._glo = None
         self.ctx = None
-        self.extra = None
+        self.extra = None  #: Any - Attribute for storing user defined objects
         raise TypeError()
 
     def use(self, location=0) -> None:

--- a/moderngl/scope.py
+++ b/moderngl/scope.py
@@ -24,7 +24,7 @@ class Scope:
     def __init__(self):
         self.mglo = None
         self.ctx = None
-        self.extra = None
+        self.extra = None  #: Any - Attribute for storing user defined objects
         raise TypeError()
 
     def __repr__(self):

--- a/moderngl/texture.py
+++ b/moderngl/texture.py
@@ -38,7 +38,7 @@ class Texture:
         self._depth = None
         self._glo = None
         self.ctx = None
-        self.extra = None
+        self.extra = None  #: Any - Attribute for storing user defined objects
         raise TypeError()
 
     def __repr__(self):

--- a/moderngl/texture_3d.py
+++ b/moderngl/texture_3d.py
@@ -26,7 +26,7 @@ class Texture3D:
         self._dtype = None
         self._glo = None
         self.ctx = None
-        self.extra = None
+        self.extra = None  #: Any - Attribute for storing user defined objects
         raise TypeError()
 
     def __repr__(self):

--- a/moderngl/texture_array.py
+++ b/moderngl/texture_array.py
@@ -26,7 +26,7 @@ class TextureArray:
         self._depth = None
         self._glo = None
         self.ctx = None
-        self.extra = None
+        self.extra = None  #: Any - Attribute for storing user defined objects
         raise TypeError()
 
     def __repr__(self):

--- a/moderngl/texture_cube.py
+++ b/moderngl/texture_cube.py
@@ -23,7 +23,7 @@ class TextureCube:
         self._dtype = None
         self._glo = None
         self.ctx = None
-        self.extra = None
+        self.extra = None  #: Any - Attribute for storing user defined objects
         raise TypeError()
 
     def __repr__(self):

--- a/moderngl/vertex_array.py
+++ b/moderngl/vertex_array.py
@@ -42,7 +42,7 @@ class VertexArray:
         self._index_element_size = None
         self._glo = None
         self.ctx = None
-        self.extra = None
+        self.extra = None  #: Any - Attribute for storing user defined objects
         raise TypeError()
 
     def __repr__(self):

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -32,61 +32,61 @@ class TestCase(unittest.TestCase):
             self.assertEqual(docsig, sig, msg=filename + '::' + method)
 
     def test_context_docs(self):
-        self.validate('context.rst', 'Context', ['release', 'mglo', 'extra', 'core_profile_check'])
+        self.validate('context.rst', 'Context', ['release', 'mglo', 'core_profile_check'])
 
     def test_program_docs(self):
-        self.validate('program.rst', 'Program', ['release', 'mglo', 'glo', 'ctx', 'extra'])
+        self.validate('program.rst', 'Program', ['release', 'mglo', 'glo', 'ctx'])
 
     def test_vertex_array_docs(self):
-        self.validate('vertex_array.rst', 'VertexArray', ['release', 'mglo', 'glo', 'ctx', 'extra'])
+        self.validate('vertex_array.rst', 'VertexArray', ['release', 'mglo', 'glo', 'ctx'])
 
     def test_buffer_docs(self):
-        self.validate('buffer.rst', 'Buffer', ['release', 'mglo', 'glo', 'ctx', 'extra'])
+        self.validate('buffer.rst', 'Buffer', ['release', 'mglo', 'glo', 'ctx'])
 
     def test_texture_docs(self):
-        self.validate('texture.rst', 'Texture', ['release', 'mglo', 'glo', 'ctx', 'extra'])
+        self.validate('texture.rst', 'Texture', ['release', 'mglo', 'glo', 'ctx'])
 
     def test_texture_array_docs(self):
-        self.validate('texture_array.rst', 'TextureArray', ['release', 'mglo', 'glo', 'ctx', 'extra'])
+        self.validate('texture_array.rst', 'TextureArray', ['release', 'mglo', 'glo', 'ctx'])
 
     def test_texture3d_docs(self):
-        self.validate('texture3d.rst', 'Texture3D', ['release', 'mglo', 'glo', 'ctx', 'extra'])
+        self.validate('texture3d.rst', 'Texture3D', ['release', 'mglo', 'glo', 'ctx'])
 
     def test_texture_cube_docs(self):
-        self.validate('texture_cube.rst', 'TextureCube', ['release', 'mglo', 'glo', 'ctx', 'extra'])
+        self.validate('texture_cube.rst', 'TextureCube', ['release', 'mglo', 'glo', 'ctx'])
 
     def test_framebuffer_docs(self):
-        self.validate('framebuffer.rst', 'Framebuffer', ['release', 'mglo', 'glo', 'ctx', 'extra'])
+        self.validate('framebuffer.rst', 'Framebuffer', ['release', 'mglo', 'glo', 'ctx'])
 
     def test_renderbuffer_docs(self):
-        self.validate('renderbuffer.rst', 'Renderbuffer', ['release', 'mglo', 'glo', 'ctx', 'extra'])
+        self.validate('renderbuffer.rst', 'Renderbuffer', ['release', 'mglo', 'glo', 'ctx'])
 
     def test_query_docs(self):
-        self.validate('query.rst', 'Query', ['mglo', 'ctx', 'extra'])
+        self.validate('query.rst', 'Query', ['mglo', 'ctx'])
 
     def test_scope_docs(self):
-        self.validate('scope.rst', 'Scope', ['mglo', 'ctx', 'extra'])
+        self.validate('scope.rst', 'Scope', ['mglo', 'ctx'])
 
     def test_compute_shader_docs(self):
-        self.validate('compute_shader.rst', 'ComputeShader', ['release', 'mglo', 'glo', 'ctx', 'extra'])
+        self.validate('compute_shader.rst', 'ComputeShader', ['release', 'mglo', 'glo', 'ctx'])
 
     def test_subroutine_docs(self):
-        self.validate('subroutine.rst', 'Subroutine', ['mglo', 'ctx', 'extra'])
+        self.validate('subroutine.rst', 'Subroutine', ['mglo', 'ctx'])
 
     def test_uniform_docs(self):
-        self.validate('uniform.rst', 'Uniform', ['mglo', 'extra'])
+        self.validate('uniform.rst', 'Uniform', ['mglo'])
 
     def test_uniform_block_docs(self):
-        self.validate('uniform_block.rst', 'UniformBlock', ['mglo', 'extra'])
+        self.validate('uniform_block.rst', 'UniformBlock', ['mglo'])
 
     def test_varying_docs(self):
-        self.validate('varying.rst', 'Varying', ['mglo', 'extra'])
+        self.validate('varying.rst', 'Varying', ['mglo'])
 
     def test_conditional_render_docs(self):
         self.validate('conditional_render.rst', 'ConditionalRender', ['mglo'])
 
     def test_sampler_docs(self):
-        self.validate('sampler.rst', 'Sampler', ['release', 'mglo', 'glo', 'ctx', 'extra'])
+        self.validate('sampler.rst', 'Sampler', ['release', 'mglo', 'glo', 'ctx'])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
1) Expose the ``extra`` attribute in docs for all types. This is a fairly important attribute to be aware of since moderngl types cannot be extended using inheritance. I personally went down an unecessary rabbit hole of making wrappers though composition before I saw the ``extra`` attribute.

2) Initialize all ``extra`` attributes on instance creation. ``program.extra`` will trigger ``AttributeError`` unless the ``extra`` attribute has previously been assigned a value. I think it's a lot more user friendly to ensure the attribute is present with a default ``None`` value. 

This default value is also advertised in most initializers, so most IDEs and code inspection tools believe the attribute is present with a default value. (They don't care about the ``TypeError()``)

https://github.com/cprogrammer1994/ModernGL/blob/a2cf2e1b20939331b25e63531f128b4f9008ab62/moderngl/program.py#L26-L34