### PR TITLE
Bug: Only set compare func if valid enum

### DIFF
--- a/src/Texture.cpp
+++ b/src/Texture.cpp
@@ -869,8 +869,8 @@ int MGLTexture_set_compare_func(MGLTexture * self, PyObject * value) {
 		gl.TexParameteri(texture_target, GL_TEXTURE_COMPARE_MODE, GL_NONE);
 	} else {
 		gl.TexParameteri(texture_target, GL_TEXTURE_COMPARE_MODE, GL_COMPARE_REF_TO_TEXTURE);
+		gl.TexParameteri(texture_target, GL_TEXTURE_COMPARE_FUNC, self->compare_func);
 	}
-	gl.TexParameteri(texture_target, GL_TEXTURE_COMPARE_FUNC, self->compare_func);
 
 	return 0;
 }


### PR DESCRIPTION
### Tiny bug fix

Only set compare func when having a valid enum.
Trying to set depth func to 0 triggers INVALID_ENUM.
