### PR TITLE
Depth texture incompleteness

### DIFF
--- a/src/Texture.cpp
+++ b/src/Texture.cpp
@@ -232,8 +232,8 @@ PyObject * MGLContext_depth_texture(MGLContext * self, PyObject * args) {
 
 	gl.BindTexture(texture_target, texture->texture_obj);
 
-	// gl.TexParameteri(texture_target, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-	// gl.TexParameteri(texture_target, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	gl.TexParameteri(texture_target, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+	gl.TexParameteri(texture_target, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 	// gl.TexParameteri(texture_target, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 	// gl.TexParameteri(texture_target, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 

--- a/src/Texture.cpp
+++ b/src/Texture.cpp
@@ -232,8 +232,8 @@ PyObject * MGLContext_depth_texture(MGLContext * self, PyObject * args) {
 
 	gl.BindTexture(texture_target, texture->texture_obj);
 
-	gl.TexParameteri(texture_target, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-	gl.TexParameteri(texture_target, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	// gl.TexParameteri(texture_target, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+	// gl.TexParameteri(texture_target, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 	// gl.TexParameteri(texture_target, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 	// gl.TexParameteri(texture_target, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 

--- a/src/Texture.cpp
+++ b/src/Texture.cpp
@@ -232,10 +232,8 @@ PyObject * MGLContext_depth_texture(MGLContext * self, PyObject * args) {
 
 	gl.BindTexture(texture_target, texture->texture_obj);
 
-	// gl.TexParameteri(texture_target, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-	// gl.TexParameteri(texture_target, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-	// gl.TexParameteri(texture_target, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-	// gl.TexParameteri(texture_target, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	gl.TexParameteri(texture_target, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+	gl.TexParameteri(texture_target, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 
 	if (samples) {
 		gl.TexImage2DMultisample(texture_target, samples, GL_DEPTH_COMPONENT24, width, height, true);


### PR DESCRIPTION
Set a sane default filtering for depth textures to avoid incompleteness issues. The default filtering would also then align with what is advertised in docs:
https://moderngl.readthedocs.io/en/stable/reference/texture.html#moderngl.Texture.filter

According to the OpenGL wiki the default min filter is ``GL_NEAREST_MIPMAP_LINEAR``:
https://www.khronos.org/opengl/wiki/Common_Mistakes#Creating_a_complete_texture

.. so this causes incompleteness issues unless explicitly set. Texture wrap defaults are all good.