### PR TITLE
Reword README comparison with PyOpenGL

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,8 @@ For complete examples please visit the [Examples](https://github.com/cprogrammer
 
 ## Compared to PyOpenGL
 
-With the original OpenGL API you have to write a couple of lines to achieve a **simple task** like compiling a shader or running a computation on the GPU. With ModernGL you will need just a **few lines** to achieve the same result.
-
-#### Using PyOpenGL
+With PyOpenGL, using the original OpenGL API, you have to write three lines to
+achieve a simple task like binding a VBO:
 
 ```py
 vbo1 = glGenBuffers(1)
@@ -64,7 +63,8 @@ GL.glBindBuffer(GL_ARRAY_BUFFER, vbo2)
 GL.glBufferData(GL_ARRAY_BUFFER, b'\x00' * 1024, GL_DYNAMIC_DRAW)
 ```
 
-#### Using ModernGL
+With ModernGL you need just one simple line per VBO to achieve the same
+results:
 
 ```py
 vbo1 = ctx.buffer(b'Hello World!')


### PR DESCRIPTION
### Description

I didn't like that the original text read something like "with PyOpenGL it takes a couple of (ie about two) lines, whereas with ModernGL it takes several (ie more than two) lines to do the same thing."

In fixing that, I decided to split the descriptive paragraph in two. The first sentence describes the following PyOpenGL code, and the second sentence describes the subsequent ModernGL code.

Once that was done, the subheadings were not needed, simplifying and condensing the appearance of the section.

Feel free to simply reject this, obviously, it's just my personal preferences.

### List of changes

- **added** ... none
- **removed** ... none
- **fixed** ... none
- **changed** ... README.md

(Curious, git already knows this information, why have a redundant, manual (ie sometimes wrong) version of it here?)

I don't feel like this is worth a contributor credit, so I won't add myself to the README, thanks.
