### PR TITLE
State requested and acquired gl version

### DIFF
--- a/moderngl/context.py
+++ b/moderngl/context.py
@@ -1107,7 +1107,8 @@ def create_context(require=None) -> Context:
     ctx.extra = None
 
     if require is not None and ctx.version_code < require:
-        raise ValueError('The version required is not provided')
+        raise ValueError('Requested OpenGL version {}, got version {}'.format(
+            require, ctx.version_code))
 
     return ctx
 


### PR DESCRIPTION
When creating a context from an existing opengl context we should state the requested and aquired opengl version to make the error message more clear.

### Description

Stumbled over this tiny detail today. We do this for standalone context, but not when using existing contexts. It make it much easier to understand when context creation fails for various reasons.