### PR TITLE
Fixed typo in texture.py

### DIFF
--- a/moderngl/texture.py
+++ b/moderngl/texture.py
@@ -95,10 +95,10 @@ class Texture:
 
             Example::
 
-                texture.filter == (monderngl.NEAREST, moderngl.NEAREST)
-                texture.filter == (monderngl.LINEAR_MIPMAP_LINEAR, moderngl.LINEAR)
-                texture.filter == (monderngl.NEAREST_MIPMAP_LINEAR, moderngl.NEAREST)
-                texture.filter == (monderngl.LINEAR_MIPMAP_NEAREST, moderngl.NEAREST)
+                texture.filter == (moderngl.NEAREST, moderngl.NEAREST)
+                texture.filter == (moderngl.LINEAR_MIPMAP_LINEAR, moderngl.LINEAR)
+                texture.filter == (moderngl.NEAREST_MIPMAP_LINEAR, moderngl.NEAREST)
+                texture.filter == (moderngl.LINEAR_MIPMAP_NEAREST, moderngl.NEAREST)
         '''
 
         return self.mglo.filter


### PR DESCRIPTION
Fixed 4 typo in texture.py for texture.filter example documentation - monderngl to moderngl
