### PR TITLE
Example window polish

### DIFF
--- a/examples/00_empty_window.py
+++ b/examples/00_empty_window.py
@@ -14,6 +14,13 @@ class EmptyWindow(Example):
     def render(self, time: float, frame_time: float):
         self.ctx.clear(0.2, 0.4, 0.7)
 
+    def resize(self, width: int, heigh: int):
+        """
+        Pick window resizes in case we need yo update
+        internal states when this happens.
+        """
+        print("Window resized to", width, heigh)
+
     def key_event(self, key, action):
         """
         Handle key events in a generic way

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,6 +3,8 @@
 Most examples are currently using the [standard example system](https://github.com/cprogrammer1994/ModernGL/tree/master/examples/window).
 It's recommended to use this as your example will be able to run on all supported platforms and window types (sdl2, pyglet, pyqt, glfw etc..)
 
+**Examples should work out of the box on Windows, Linux and OS X.**
+
 ## Example Options
 
 ```

--- a/examples/window/README.md
+++ b/examples/window/README.md
@@ -133,6 +133,14 @@ class MyExample(Example):
         self.ctx.clear(0.2, 0.4, 0.7)
         # Render stuff here
 
+    # ------------ OPTIONAL METHODS --------------
+
+    def resize(self, width: int, heigh: int):
+        """
+        Pick window resizes in case we need to update internal states.
+        """
+        print("Window resized to", width, heigh)
+
     def key_event(self, key, action):
         """
         Handle key events in a generic way supporting all window types.

--- a/examples/window/README.md
+++ b/examples/window/README.md
@@ -5,9 +5,11 @@ ModernGL can only create contexts in headless mode and relies on other libraries
 to create a context displaying a visible window. ModernGL will then load OpenGL
 functions from the existing contexts instead.
 
-
 This package contains examples using ModernGL with various libraries
 opening a visible window.
+
+**Most example windows should work on Windows, Linux and OS X.
+Some require additional setup such as installing dynamic libraries.**
 
 ## PyQt5
 

--- a/examples/window/__init__.py
+++ b/examples/window/__init__.py
@@ -4,6 +4,7 @@ import time
 
 from importlib import import_module
 from pathlib import Path
+from typing import List
 
 from window.base import Example, BaseWindow
 
@@ -55,7 +56,9 @@ def run_example(example_cls: Example, args=None):
 
 
 def get_window_cls(window: str) -> BaseWindow:
-    """Attept to obtain the configured window class"""
+    """
+    Attept to obtain the configured window class
+    """
     return import_string('window.{}.window.Window'.format(window))
 
 
@@ -96,8 +99,13 @@ def parse_args(args=None):
     return parser.parse_args(args or sys.argv[1:])
 
 
-def find_window_classes():
-    """Find available window packages"""
+def find_window_classes() -> List[str]:
+    """
+    Find available window packages
+
+    Returns:
+        A list of avaialble window packages
+    """
     return [
         path.parts[-1] for path in Path(__file__).parent.iterdir()
         if path.is_dir() and not path.parts[-1].startswith('__')

--- a/examples/window/glfw/keys.py
+++ b/examples/window/glfw/keys.py
@@ -4,7 +4,9 @@ from window.base import BaseKeys
 
 
 class Keys(BaseKeys):
-    """Namespace defining glfw specific keys constants"""
+    """
+    Namespace defining glfw specific keys constants
+    """
     ACTION_PRESS = glfw.PRESS
     ACTION_RELEASE = glfw.RELEASE
 

--- a/examples/window/glfw/window.py
+++ b/examples/window/glfw/window.py
@@ -128,4 +128,4 @@ class Window(BaseWindow):
         self.buffer_width, self.buffer_height = glfw.get_framebuffer_size(self.window)
         self.set_default_viewport()
 
-        super().resize(width, height)
+        super().resize(self.buffer_width, self.buffer_height)

--- a/examples/window/glfw/window.py
+++ b/examples/window/glfw/window.py
@@ -6,6 +6,9 @@ from window.glfw.keys import Keys
 
 
 class Window(BaseWindow):
+    """
+    Window based on GLFW
+    """
     keys = Keys
 
     def __init__(self, **kwargs):
@@ -31,15 +34,14 @@ class Window(BaseWindow):
             # Use the primary monitors current resolution
             monitor = glfw.get_primary_monitor()
             mode = glfw.get_video_mode(monitor)
+            self.width, self.height = mode.size.width, mode.size.height
 
-            # Make sure video more switching will not happen by
-            # matching the desktops current vide mode
+            # Make sure video mode switching will not happen by
+            # matching the desktops current video mode
             glfw.window_hint(glfw.RED_BITS, mode.bits.red)
             glfw.window_hint(glfw.GREEN_BITS, mode.bits.green)
             glfw.window_hint(glfw.BLUE_BITS, mode.bits.blue)
             glfw.window_hint(glfw.REFRESH_RATE, mode.refresh_rate)
-
-            self.width, self.height = mode.size.width, mode.size.height
 
         self.window = glfw.create_window(self.width, self.height, self.title, monitor, None)
 
@@ -66,21 +68,25 @@ class Window(BaseWindow):
         self.set_default_viewport()
 
     def close(self):
+        """
+        Suggest to glfw the window should be closed soon
+        """
         glfw.set_window_should_close(self.window, True)
 
     @property
     def is_closing(self):
+        """
+        Checks if the window is scheduled for closing
+        """
         return glfw.window_should_close(self.window)
 
     def swap_buffers(self):
-        self.frames += 1
+        """
+        Swap buffers, increment frame counter and pull events
+        """
         glfw.swap_buffers(self.window)
+        self.frames += 1
         glfw.poll_events()
-
-    def destroy(self):
-        glfw.terminate()
-
-    # GLFW specific callbacks
 
     def key_event_callback(self, window, key, scancode, action, mods):
         """
@@ -113,6 +119,10 @@ class Window(BaseWindow):
         self.example.mouse_position_event(xpos, ypos)
 
     def mouse_button_callback(self, window, button, action, mods):
+        """
+        Handle mouse button events and forward them to the example
+        """
+        # Offset button index by 1 to make it match the other libraries
         button += 1
         # Support left and right mouse button for now
         if button not in [1, 2]:
@@ -139,3 +149,10 @@ class Window(BaseWindow):
         self.set_default_viewport()
 
         super().resize(self.buffer_width, self.buffer_height)
+
+    def destroy(self):
+        """
+        Gracefully terminate GLFW.
+        This will also properly terminate the window and context
+        """
+        glfw.terminate()

--- a/examples/window/glfw/window.py
+++ b/examples/window/glfw/window.py
@@ -14,6 +14,9 @@ class Window(BaseWindow):
         if not glfw.init():
             raise ValueError("Failed to initialize glfw")
 
+        # Configure the OpenGL context
+        glfw.window_hint(glfw.CONTEXT_CREATION_API, glfw.NATIVE_CONTEXT_API)
+        glfw.window_hint(glfw.CLIENT_API, glfw.OPENGL_API)
         glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, self.gl_version[0])
         glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, self.gl_version[1])
         glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
@@ -28,6 +31,13 @@ class Window(BaseWindow):
             # Use the primary monitors current resolution
             monitor = glfw.get_primary_monitor()
             mode = glfw.get_video_mode(monitor)
+
+            # Make sure video more switching will not happen by
+            # matching the desktops current vide mode
+            glfw.window_hint(glfw.RED_BITS, mode.bits.red)
+            glfw.window_hint(glfw.GREEN_BITS, mode.bits.green)
+            glfw.window_hint(glfw.BLUE_BITS, mode.bits.blue)
+            glfw.window_hint(glfw.REFRESH_RATE, mode.refresh_rate)
 
             self.width, self.height = mode.size.width, mode.size.height
 

--- a/examples/window/pyglet/window.py
+++ b/examples/window/pyglet/window.py
@@ -41,6 +41,13 @@ class Window(BaseWindow):
         config.sample_buffers = 1 if self.samples > 1 else 0
         config.samples = self.samples
 
+        # Obtain the default destop screen's resolution
+        if self.fullscreen:
+            platform = pyglet.window.get_platform()
+            display = platform.get_default_display()
+            screen = display.get_default_screen()
+            self.width, self.height = screen.width, screen.height
+
         # Create window wrapper
         self.window = PygletWrapper(
             width=self.width, height=self.height,

--- a/examples/window/pyglet/window.py
+++ b/examples/window/pyglet/window.py
@@ -117,8 +117,9 @@ class Window(BaseWindow):
         """
         self.width, self.height = width, height
         self.buffer_width, self.buffer_height = width, height
-        self.resize(width, height)
         self.set_default_viewport()
+
+        super().resize(self.buffer_width, self.buffer_height)
 
     def close(self):
         self.window.close()

--- a/examples/window/pyglet/window.py
+++ b/examples/window/pyglet/window.py
@@ -19,8 +19,9 @@ if platform.system() == "Darwin":
 class Window(BaseWindow):
     """
     Window based on Pyglet 1.x.
-    This pyglet version is not able to create core contexts
-    and do not work on OS X until 2.x is out.
+
+    This pyglet version is not able to create forward compatible
+    core contexts and do not work on OS X until 2.x is out.
     """
     keys = Keys
 
@@ -36,6 +37,7 @@ class Window(BaseWindow):
         config.major_version = self.gl_version[0]
         config.minor_version = self.gl_version[1]
         config.forward_compatible = True
+        # MISSING: Core context flag
         config.sample_buffers = 1 if self.samples > 1 else 0
         config.samples = self.samples
 
@@ -47,8 +49,11 @@ class Window(BaseWindow):
             vsync=self.vsync,
             fullscreen=self.fullscreen,
         )
+
+        # Show/hide mouse cursor
         self.window.set_mouse_visible(self.cursor)
 
+        # Override the default event callbacks
         self.window.event(self.on_key_press)
         self.window.event(self.on_key_release)
         self.window.event(self.on_mouse_motion)
@@ -62,56 +67,70 @@ class Window(BaseWindow):
 
     @property
     def is_closing(self):
+        """
+        Check pyglet's internal exit state
+        """
         return self.window.has_exit
+
+    def close(self):
+        """
+        Close the pyglet window directly
+        """
+        self.window.close()
 
     def swap_buffers(self):
         """
         Swap buffers, increment frame counter and pull events
         """
-        if not self.window.context:
-            return
-
-        self.frames += 1
         self.window.flip()
+        self.frames += 1
         self.window.dispatch_events()
 
     def on_key_press(self, symbol, modifiers):
         """
         Pyglet specific key press callback.
-        Forwards and translates the events to :py:func:`keyboard_event`
+        Forwards and translates the events to the example
         """
         self.example.key_event(symbol, self.keys.ACTION_PRESS)
 
     def on_key_release(self, symbol, modifiers):
         """
         Pyglet specific key release callback.
-        Forwards and translates the events to :py:func:`keyboard_event`
+        Forwards and translates the events to the example
         """
         self.example.key_event(symbol, self.keys.ACTION_RELEASE)
 
     def on_mouse_motion(self, x, y, dx, dy):
         """
         Pyglet specific mouse motion callback.
-        Forwards and traslates the event to :py:func:`cursor_event`
+        Forwards and traslates the event to the example
         """
-        # screen coordinates relative to the lower-left corner
+        # Screen coordinates relative to the lower-left corner
+        # so we have to flip the y axis to make this consistent with
+        # other window libraries
         self.example.mouse_position_event(x, self.buffer_height - y)
 
-    def on_mouse_press(self, x, y, button, mods):
+    def on_mouse_press(self, x: int, y: int, button, mods):
+        """
+        Handle mouse press events and forward to example window
+        """
         if button in [1, 4]:
             self.example.mouse_press_event(
                 x, self.buffer_height - y,
                 1 if button == 1 else 2,
             )
 
-    def on_mouse_release(self,  x, y, button, mods):
+    def on_mouse_release(self, x: int, y: int, button, mods):
+        """
+        Handle mouse release events and forward to example window
+        """
         if button in [1, 4]:
             self.example.mouse_release_event(
                 x, self.buffer_height - y,
                 1 if button == 1 else 2,
             )
 
-    def on_resize(self, width, height):
+    def on_resize(self, width: int, height: int):
         """
         Pyglet specific callback for window resize events.
         """
@@ -121,32 +140,27 @@ class Window(BaseWindow):
 
         super().resize(self.buffer_width, self.buffer_height)
 
-    def close(self):
-        self.window.close()
-
     def destroy(self):
+        """
+        Nothing to do here as close() is doing the cleanup
+        """
         pass
-
 
 
 class PygletWrapper(pyglet.window.Window):
     """
-    Block out some window methods so pyglet behaves
-    as it was not designed to deal with 2.1+ contexts.
-
-    Avoids various GL errors triggered by calls
-    to deprecated functions until Pyglet 2.x is out.
+    Block out some window methods so pyglet don't trigger GL errors
     """
 
     def on_resize(self, width, height):
-        """For some reason pyglet calls its own resize handler randomly"""
-        pass
-
-    def on_mouse_motion(self, x, y, dx, dy):
-        pass
-
-    def on_mouse_press(self, x, y, button, modifiers):
+        """
+        Block out the resize method.
+        For some reason pyglet calls this triggering errors.
+        """
         pass
 
     def on_draw(self):
+        """
+        Block out the dfault draw method to avoid GL errors.
+        """
         pass

--- a/examples/window/pyqt5/keys.py
+++ b/examples/window/pyqt5/keys.py
@@ -5,7 +5,7 @@ from window.base import BaseKeys
 
 class Keys(BaseKeys):
     """
-    Namespace creating pyqt specific key constants
+    Namespace mapping pyqt specific key constants
     """
     ESCAPE = Qt.Key_Escape
     SPACE = Qt.Key_Space

--- a/examples/window/pyqt5/window.py
+++ b/examples/window/pyqt5/window.py
@@ -6,11 +6,20 @@ from window.pyqt5.keys import Keys
 
 
 class Window(BaseWindow):
+    """
+    A basic window implementation using PyQt5 with the goal of
+    creating an OpenGL context and handle keyboard and mouse input.
+
+    This window bypasses Qt's own event loop to make things as flexible as possible.
+
+    If you need to use the event loop and are using other features
+    in Qt as well, this example can still be useful as a reference
+    when creating your own window.
+    """
     keys = Keys
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._closed = False
 
         # Specify OpenGL context parameters
         gl = QtOpenGL.QGLFormat()
@@ -20,18 +29,20 @@ class Window(BaseWindow):
         gl.setDoubleBuffer(True)
         gl.setSwapInterval(1 if self.vsync else 0)
 
+        # Configure multisampling if needed
         if self.samples > 1:
             gl.setSampleBuffers(True)
             gl.setSamples(self.samples)
 
-        # We need an application object, but we are not using the event loop
+        # We need an application object, but we are bypassing the library's
+        # internal event loop to avoid unnecessary work
         self.app = QtWidgets.QApplication([])
 
         # Create the OpenGL widget
         self.widget = QtOpenGL.QGLWidget(gl)
         self.widget.setWindowTitle(self.title)
 
-        # Fetch desktop size
+        # If fullscreen we change the window to match the desktop on the primary screen
         if self.fullscreen:
             rect = QtWidgets.QDesktopWidget().screenGeometry()
             self.width = rect.width()
@@ -40,6 +51,7 @@ class Window(BaseWindow):
             self.buffer_height = rect.height() * self.widget.devicePixelRatio()
 
         if self.resizable:
+            # Ensure a valid resize policy when window is resizable
             size_policy = QtWidgets.QSizePolicy(
                 QtWidgets.QSizePolicy.Expanding,
                 QtWidgets.QSizePolicy.Expanding,
@@ -48,17 +60,21 @@ class Window(BaseWindow):
             self.widget.resize(self.width, self.height)
         else:
             self.widget.setFixedSize(self.width, self.height)
+        
+        # Center the window on the screen if in window mode
+        if not self.fullscreen:
+            self.widget.move(QtWidgets.QDesktopWidget().rect().center() - self.widget.rect().center())
 
-        self.widget.move(QtWidgets.QDesktopWidget().rect().center() - self.widget.rect().center())
         # Needs to be set before show()
         self.widget.resizeGL = self.resize
-        self.widget.show()
 
         if not self.cursor:
             self.widget.setCursor(QtCore.Qt.BlankCursor)
 
         if self.fullscreen:
             self.widget.showFullScreen()
+        else:
+            self.widget.show()
 
         # We want mouse position events
         self.widget.setMouseTracking(True)
@@ -78,40 +94,59 @@ class Window(BaseWindow):
         self.buffer_width = self.width * self.widget.devicePixelRatio()
         self.buffer_height = self.height * self.widget.devicePixelRatio()
 
-        self.print_context_info()
         self.set_default_viewport()
+        self.print_context_info()
 
     def swap_buffers(self):
+        """
+        Swap buffers, set viewport, trigger events and increment frame counter
+        """
         self.widget.swapBuffers()
         self.set_default_viewport()
         self.app.processEvents()
         self.frames += 1
 
-    def resize(self, width, height):
-        # pyqt reports sizes in actual buffer size (not window size)
-        self.width = width // self.widget.devicePixelRatio()
-        self.height = height // self.widget.devicePixelRatio()
-        self.buffer_width = width
-        self.buffer_height = height
+    def resize(self, width: int,  height: int):
+        """
+        Replacement for Qt's resizeGL method.
+        """
+        self.width = width
+        self.height = height
+
+        self.buffer_width = self.width * self.widget.devicePixelRatio()
+        self.buffer_height = self.height * self.widget.devicePixelRatio()
 
         if self.ctx:
             self.set_default_viewport()
 
-        super().resize(width, height)
+        # Make sure we notify the example about the resize
+        super().resize(self.buffer_width, self.buffer_height)
 
     def key_pressed_event(self, event):
+        """
+        Process Qt key press events forwarding them to the example
+        """
         if event.key() == self.keys.ESCAPE:
             self.close()
 
         self.example.key_event(event.key(), self.keys.ACTION_PRESS)
 
     def key_release_event(self, event):
+        """
+        Process Qt key release events forwarding them to the example
+        """
         self.example.key_event(event.key(), self.keys.ACTION_RELEASE)
 
     def mouse_move_event(self, event):
+        """
+        Forward mouse cursor position events to the example
+        """
         self.example.mouse_position_event(event.x(), event.y())
 
     def mouse_press_event(self, event):
+        """
+        Forward mouse press events to the example
+        """
         # Support left and right mouse button for now
         if event.button() not in [1, 2]:
             return
@@ -119,6 +154,9 @@ class Window(BaseWindow):
         self.example.mouse_press_event(event.x(), event.y(), event.button())
 
     def mouse_release_event(self, event):
+        """
+        Forward mouse release events to the example
+        """
         # Support left and right mouse button for now
         if event.button() not in [1, 2]:
             return
@@ -126,14 +164,13 @@ class Window(BaseWindow):
         self.example.mouse_release_event(event.x(), event.y(), event.button())
 
     def close_event(self, event):
+        """
+        Detect the standard PyQt close events to make users happy
+        """
         self.close()
 
-    @property
-    def is_closing(self):
-        return self._closed
-
-    def close(self):
-        self._closed = True
-
     def destroy(self):
-         QtCore.QCoreApplication.instance().quit()
+        """
+        Quit the Qt application to exit the window gracefully
+        """
+        QtCore.QCoreApplication.instance().quit()

--- a/examples/window/pyqt5/window.py
+++ b/examples/window/pyqt5/window.py
@@ -110,11 +110,10 @@ class Window(BaseWindow):
         """
         Replacement for Qt's resizeGL method.
         """
-        self.width = width
-        self.height = height
-
-        self.buffer_width = self.width * self.widget.devicePixelRatio()
-        self.buffer_height = self.height * self.widget.devicePixelRatio()
+        self.width = width // self.widget.devicePixelRatio()
+        self.height = height // self.widget.devicePixelRatio()
+        self.buffer_width = width
+        self.buffer_height = height
 
         if self.ctx:
             self.set_default_viewport()

--- a/examples/window/sdl2/keys.py
+++ b/examples/window/sdl2/keys.py
@@ -4,7 +4,9 @@ from window.base import BaseKeys
 
 
 class Keys(BaseKeys):
-    """Namespace defining sdl2 specific keys constants"""
+    """
+    Namespace mapping SDL2 specific key constants
+    """
     ACTION_PRESS = sdl2.SDL_KEYDOWN
     ACTION_RELEASE = sdl2.SDL_KEYUP
 

--- a/examples/window/sdl2/window.py
+++ b/examples/window/sdl2/window.py
@@ -77,6 +77,8 @@ class Window(BaseWindow):
         self.buffer_width, self.buffer_height = self.width, self.height
         self.set_default_viewport()
 
+        super().resize(self.buffer_width, self.buffer_height)
+
     def process_events(self):
         for event in sdl2.ext.get_events():
             if event.type == sdl2.SDL_MOUSEMOTION:

--- a/examples/window/sdl2/window.py
+++ b/examples/window/sdl2/window.py
@@ -8,35 +8,43 @@ from window.sdl2.keys import Keys
 
 
 class Window(BaseWindow):
+    """
+    Basic window implementation using SDL2.
+    """
     keys = Keys
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-        self._window_closing = False
-
         if sdl2.SDL_Init(sdl2.SDL_INIT_VIDEO) != 0:
             raise ValueError("Failed to initialize sdl2")
 
+        # Configure OpenGL context
         sdl2.video.SDL_GL_SetAttribute(sdl2.SDL_GL_CONTEXT_MAJOR_VERSION, self.gl_version[0])
         sdl2.video.SDL_GL_SetAttribute(sdl2.SDL_GL_CONTEXT_MINOR_VERSION, self.gl_version[1])
         sdl2.video.SDL_GL_SetAttribute(sdl2.SDL_GL_CONTEXT_PROFILE_MASK, sdl2.SDL_GL_CONTEXT_PROFILE_CORE)
         sdl2.video.SDL_GL_SetAttribute(sdl2.SDL_GL_CONTEXT_FORWARD_COMPATIBLE_FLAG, 1)
         sdl2.video.SDL_GL_SetAttribute(sdl2.SDL_GL_DOUBLEBUFFER, 1)
         sdl2.video.SDL_GL_SetAttribute(sdl2.SDL_GL_DEPTH_SIZE, 24)
+
+        # Display/hide mouse cursor
         sdl2.SDL_ShowCursor(sdl2.SDL_ENABLE if self.cursor else sdl2.SDL_DISABLE)
 
+        # Configure multisampling
         if self.samples > 1:
             sdl2.video.SDL_GL_SetAttribute(sdl2.SDL_GL_MULTISAMPLEBUFFERS, 1)
             sdl2.video.SDL_GL_SetAttribute(sdl2.SDL_GL_MULTISAMPLESAMPLES, self.samples)
 
+        # Built the window flags
         flags = sdl2.SDL_WINDOW_OPENGL
         if self.fullscreen:
+            # Use primary desktop screen resolution
             flags |= sdl2.SDL_WINDOW_FULLSCREEN_DESKTOP
         else:
             if self.resizable:
                 flags |= sdl2.SDL_WINDOW_RESIZABLE
 
+        # Create the window
         self.window = sdl2.SDL_CreateWindow(
             self.title.encode(),
             sdl2.SDL_WINDOWPOS_UNDEFINED,
@@ -56,17 +64,14 @@ class Window(BaseWindow):
         self.set_default_viewport()
         self.print_context_info()
 
-    @property
-    def is_closing(self):
-        return self._window_closing
-
-    def close(self):
-        self._window_closing = True
-
     def swap_buffers(self):
-        self.frames += 1
+        """
+        Swap buffers, set viewport, trigger events and increment frame counter
+        """
         sdl2.SDL_GL_SwapWindow(self.window)
+        self.set_default_viewport()
         self.process_events()
+        self.frames += 1
 
     def resize(self, width, height):
         """
@@ -80,6 +85,9 @@ class Window(BaseWindow):
         super().resize(self.buffer_width, self.buffer_height)
 
     def process_events(self):
+        """
+        Loop through and handle all the queued events.
+        """
         for event in sdl2.ext.get_events():
             if event.type == sdl2.SDL_MOUSEMOTION:
                 self.example.mouse_position_event(event.motion.x, event.motion.y)
@@ -114,6 +122,9 @@ class Window(BaseWindow):
                     self.resize(event.window.data1, event.window.data2)
 
     def destroy(self):
+        """
+        Gracefully close the window
+        """
         sdl2.SDL_GL_DeleteContext(self.context)
         sdl2.SDL_DestroyWindow(self.window)
         sdl2.SDL_Quit()


### PR DESCRIPTION
I went through code and did more extensive testing:

* **pyqt5**: Entering fullscreen mode was slow and glitchy. Should be a lot more snappy now.
    * Don't try to center a fulllscreen window. This caused the window to glitch for a moment
    * Only call `windget.show()` in fullscreen mode. We only need to call `showFullscreen()`. This avoids sudden flickering in the first couple of seconds after the window is created.
* **glfw**: Match the exact video mode of the desktop to avoid video mode switching when entering fullscreen
* **pyglet**: Use the current desktop size in fullscreen mode to avoid video mode switching
* **Bug**: Not all windows called `resize` on the example instance
* **Bug**: Always report `buffer_size` to the example instead of the window size
* **Improvement**: Remove redundant `close` and `is_closing` members and rely on base class when possible
* **Improvement**: Mention supported platforms in `README`
* **Improvement**: Add more comments and fix spotted typos

I think ModernGL example windows are actually better than the ones in demosys-py. I need to do somthing about that soon 😄 