### PR TITLE
docs: 'pip install' commands should use lower case 'moderngl'

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 # ModernGL
 
 ```sh
-pip install ModernGL
+pip install moderngl
 ```
 
 - [Documentation](https://moderngl.readthedocs.io/)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -5,7 +5,7 @@ Install ModernGL with :command:`pip`:
 
 .. code-block:: sh
 
-    $ pip install ModernGL
+    $ pip install moderngl
 
 Version check:
 

--- a/examples/old-examples/README.md
+++ b/examples/old-examples/README.md
@@ -20,7 +20,7 @@ Most of the examples depend on the following modules:
 It is reccommanded to install these before running the examples.
 
 ```sh
-pip install ModernGL Pyrr Pillow numpy
+pip install moderngl Pyrr Pillow numpy
 ```
 
 Don't forget to install the module for window support.

--- a/examples/old-examples/standalone/README.md
+++ b/examples/old-examples/standalone/README.md
@@ -9,7 +9,7 @@ ModernGL examples that can be run on servers.
 ## Requirements
 
 ```shell
-pip install ModernGL Pillow Pyrr numpy
+pip install moderngl Pillow Pyrr numpy
 ```
 
 ## Running examples without a display
@@ -30,7 +30,7 @@ sudo apt-get update
 sudo apt-get install -y xvfb python3 python3-virtualenv
 python3 -m virtualenv --python=python3 venv
 source venv/bin/activate
-pip install ModernGL Pillow Pyrr numpy
+pip install moderngl Pillow Pyrr numpy
 Xvfb -screen 0 640x480x24 :99 &
 export DISPLAY=:99.0
 wget https://raw.githubusercontent.com/cprogrammer1994/ModernGL/master/examples/standalone/01_hello_world.py
@@ -45,7 +45,7 @@ sudo apt-get update
 sudo apt-get install -y xvfb python3 python3-virtualenv
 python3 -m virtualenv --python=python3 venv
 source venv/bin/activate
-pip install ModernGL Pillow Pyrr numpy
+pip install moderngl Pillow Pyrr numpy
 wget https://raw.githubusercontent.com/cprogrammer1994/ModernGL/master/examples/standalone/01_hello_world.py
 xvfb-run --auto-servernum --server-args='-screen 0 640x480x24' python 01_hello_world.py
 ls 01_hello_world.png

--- a/examples/old-examples/tkinter/README.md
+++ b/examples/old-examples/tkinter/README.md
@@ -1,5 +1,5 @@
 ## Requirements
 
 ```
-pip install ModernGL Pillow Pyrr numpy
+pip install moderngl Pillow Pyrr numpy
 ```


### PR DESCRIPTION
### Description

The docs and examples contain a few 'pip install' commands that show the older:

    pip install ModernGL

I changed them to use the latest lower-cased:

    pip install moderngl

I'm just assuming that all the docs and examples still work correctly on v5.x. It could be that I've updated things that should have remained as they are. 

Thank you for the invitation to add myself to the README but my contributions are all so tiny that I don't feel worthy. Hugs!
